### PR TITLE
Add product-design skill and extend copywriting with state copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![skills.sh](https://skills.sh/b/mblode/agent-skills)](https://skills.sh/mblode/agent-skills)
 
-25 skills for shipping better software.
+26 skills for shipping better software.
 
 ## Quickstart
 
@@ -27,6 +27,7 @@ Code review catches logic bugs. Nobody checks the loading states, the type scale
 
 ### Design
 
+- **[product-design](./skills/product-design/SKILL.md)**: Product and UX judgment and correctness: the right interaction, action naming by object, scope, and consequence, reachable-state coverage, resilience, and accessibility as a product concern. Routes by mode (shape, implement, review, copy, harden), ships a runnable ESLint plugin, and defers visual build to ui-design, audits to ui-audit and ux-audit, and copy to copywriting.
 - **[ui-design](./skills/ui-design/SKILL.md)**: Designs and builds UI end to end: visual direction (palettes, type scales, tokens, CRO, brand kits), Tailwind implementation with the ui.sh design guidelines, multi-variant browser picker, screenshot-to-markup scaffolding, dark-mode and responsive retrofits, and componentization with Tailwind class cleanup.
 - **[ui-animation](./skills/ui-animation/SKILL.md)**: Designs, implements, and reviews UI motion: springs, gestures, easing, CSS transition recipes.
 - **[reverse-engineer-animation](./skills/reverse-engineer-animation/SKILL.md)**: Extract easing, spring, and choreography from a screen recording and emit CSS, Motion, SwiftUI, RN, or UIKit code.
@@ -35,7 +36,7 @@ Code review catches logic bugs. Nobody checks the loading states, the type scale
 
 ### Writing
 
-- **[copywriting](./skills/copywriting/SKILL.md)**: Short product and marketing copy; persuasion frameworks, seven sweeps, AI-ism removal, before/after diffs.
+- **[copywriting](./skills/copywriting/SKILL.md)**: Short product and marketing copy; persuasion frameworks, seven sweeps, AI-ism removal, before/after diffs, and product-state copy (destructive CTAs, error, empty, and loading strings).
 - **[blog-post](./skills/blog-post/SKILL.md)**: Long-form blog posts (listicles, tutorials, narratives, thought leadership) with research, SEO, and polish.
 - **[docs-writing](./skills/docs-writing/SKILL.md)**: Technical docs. Diataxis doc types, 52 rules, audit and writing workflows.
 - **[readme-creator](./skills/readme-creator/SKILL.md)**: Writes or rewrites a README tailored to the project type, validated against quality checks.

--- a/skills/copywriting/SKILL.md
+++ b/skills/copywriting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: copywriting
-description: Writes and edits short product and marketing copy using persuasion frameworks, and removes AI writing patterns. Writing mode gathers context, locks a brief, discovers brand voice, picks a framework, and outputs 2-3 alternatives. Editing mode audits against frameworks, strips AI-isms, runs seven sweeps, and outputs a before/after diff. Use when writing landing pages, hero copy, CTAs, product descriptions, onboarding strings, or email subjects. Also use for "this is a bad sell", "write copy for", "rewrite from first principles", "use Simon Sinek", "show don't tell", "make this shorter", "fix the copy", "write a headline", "improve the CTA", "edit existing copy", "remove AI-isms", "clean up AI writing", "make this sound less like AI", "flag AI patterns", or "scan for AI tells". For long-form articles use blog-post; for slide copy use presentation-creator; for API or product docs use docs-writing.
+description: Writes and edits short product and marketing copy using persuasion frameworks, and removes AI writing patterns. Writing mode gathers context, locks a brief, discovers brand voice, picks a framework, and outputs 2-3 alternatives. Editing mode audits against frameworks, strips AI-isms, runs seven sweeps, and outputs a before/after diff. Use when writing landing pages, hero copy, CTAs, product descriptions, onboarding strings, or email subjects. Also use for naming actions, destructive CTAs, and error, empty, and loading-state copy. Also use for "this is a bad sell", "write copy for", "rewrite from first principles", "use Simon Sinek", "show don't tell", "make this shorter", "fix the copy", "write a headline", "improve the CTA", "edit existing copy", "remove AI-isms", "clean up AI writing", or "flag AI patterns". For long-form articles use blog-post; for slide copy use presentation-creator; for API or product docs use docs-writing; for the product decision behind an action use product-design.
 ---
 
 # Copywriting
@@ -23,6 +23,7 @@ Two modes. **Auto-detect, do not ask:**
 | `references/word-lists.md` | Flagging Tier 1/2/3 AI vocabulary (Edit Step 4) |
 | `references/ai-patterns.md` | Flagging structural and sentence-level AI tells and triaging by P0/P1/P2 severity (Edit Step 4) |
 | `references/sweeps.md` | Running the seven line-level sweeps (Edit Step 5) |
+| `references/ui-states.md` | Naming actions, writing destructive CTAs, or error, empty, and loading-state copy |
 
 ---
 
@@ -173,6 +174,7 @@ Attach a label inline to every weak line. Use exactly these labels:
 | `[JARGON]` | Technical term that obscures meaning for a non-expert reader |
 | `[NO-PROOF]` | Claim that needs a number, example, or testimonial to be credible |
 | `[WEAK-CTA]` | CTA describes the action, not the outcome |
+| `[STATE-COPY]` | Vague, leaky, or dead-end state string, or a destructive CTA labeled "Confirm"/"OK"/bare verb (see `references/ui-states.md` for the rule IDs) |
 | `[AI-ISM]` | AI writing pattern: Tier 1 word, Tier 2 cluster, or structural tell |
 
 Flag the 3-7 weakest elements. Prioritise by impact on conversion or comprehension.
@@ -257,3 +259,4 @@ Also ban **"simple"** used as a claim ("our simple onboarding"): never earned up
 | To optimise meta descriptions and page titles | `optimise-seo` |
 | To review the full UI including copy in context | `ui-audit` |
 | For landing page visual design, CRO strategy, and conversion benchmarks | `ui-design` (marketing track) |
+| For the product decision of which action exists and its scope and consequence | `product-design` |

--- a/skills/copywriting/references/ui-states.md
+++ b/skills/copywriting/references/ui-states.md
@@ -1,0 +1,112 @@
+# UI State Copy
+
+Read when naming actions, writing destructive CTAs, or writing error, empty, and loading copy. This is product-state copy, not marketing copy: the words a user reads while doing a task, where clarity about object, scope, and consequence matters more than persuasion.
+
+This file defines stable rule IDs that the `product-design` skill cites when it routes naming and state decisions here. Keep the IDs exactly as written.
+
+## Contents
+
+- Destructive CTAs and action labels
+- Canonical product verbs
+- Error-state copy
+- Empty-state copy
+- Loading-state copy
+- Rule IDs
+
+## Destructive CTAs and action labels
+
+### rule/destructive-names-action
+
+Destructive and primary CTAs use Verb plus Noun naming the exact object. The button says what it does.
+
+| Bad | Good |
+|-----|------|
+| `Confirm` | `Delete project` |
+| `OK` | `Remove member` |
+| `Yes` | `Discard changes` |
+| `Delete` (bare) | `Delete 3 files` |
+| `Submit` (on a destructive action) | `Cancel subscription` |
+
+A label that does not name the object forces the user to reconstruct the consequence from surrounding text, which they often skip.
+
+### rule/no-confirm-ok-labels
+
+Never label a destructive or consequential action `Confirm`, `OK`, `Yes`, or a bare verb. These hide what happens. The exception is a purely informational dialog with a single dismiss action and no consequence, where `Got it` or `Close` is fine.
+
+## Canonical product verbs
+
+### rule/canonical-verb
+
+Use one verb per operation, consistently across the product. Do not call the same operation "Delete" on one screen and "Remove" on another. The verb carries the consequence, so the wrong verb misleads.
+
+| Verb | Means | Reversible | Not |
+|------|-------|------------|-----|
+| Create | Make a new object | n/a | Add |
+| Add | Attach an existing object to something | usually | Create |
+| Delete | Permanently destroy the object | no | Remove |
+| Remove | Detach without destroying | yes | Delete |
+| Archive | Reversibly hide from the default view | yes | Delete |
+| Save | Persist current edits | n/a | Apply |
+| Apply | Commit a configuration that takes effect | varies | Save |
+| Cancel | Abandon an in-progress action | n/a | Discard |
+| Discard | Drop unsaved edits | no | Cancel |
+| Duplicate | Copy the object | n/a | Clone |
+| Move | Relocate without copying | yes | Transfer |
+
+When two verbs both fit, pick the one whose consequence matches the action, then use it everywhere for that action.
+
+## Error-state copy
+
+### rule/error-states-recovery
+
+An error states three things: what happened, why when known, and the recovery action. It never shows raw exception or stack text, and never a bare "Something went wrong" with no next step.
+
+| Bad | Good |
+|-----|------|
+| `Something went wrong` | `Could not save your changes. Check your connection and try again.` |
+| `Error 500` | `The server could not process this request. Try again in a moment.` |
+| `Invalid input` | `Enter an email address, like name@example.com.` |
+| `TypeError: cannot read property 'id' of undefined` | `We could not load this project. Refresh to try again.` |
+
+Separate field-level errors (fix this input, shown inline) from surface-level errors (the action failed, shown near the action). Preserve everything the user typed; never clear the form on a failed submit.
+
+## Empty-state copy
+
+### rule/empty-state-action
+
+An empty state names the object and offers the first action. No dead ends. Distinguish never-had-any (guide the first step) from filtered-to-zero (offer to clear the filter).
+
+| Bad | Good |
+|-----|------|
+| `No data` | `No projects yet. Create your first project to get started.` (with a Create action) |
+| `Nothing here` | `No members match "designer". Clear the filter to see all members.` |
+| `Empty` | `No invoices yet. They appear here after your first payment.` |
+
+An empty state is often a first impression. Treat it as onboarding, not as an error.
+
+## Loading-state copy
+
+### rule/loading-state-specific
+
+Prefer specific loading copy over a bare "Loading..." when the target is known. Say what is loading, and for long operations, roughly how long.
+
+| Bad | Good |
+|-----|------|
+| `Loading...` | `Loading your projects...` |
+| `Please wait` | `Importing 1,240 rows. This takes about a minute.` |
+| `...` | `Deploying. Usually under 30 seconds.` |
+
+Keep the triggering control's label stable while it is busy; use its loading affordance rather than swapping the text, so the layout does not jump and the user can still see which action is in flight.
+
+## Rule IDs
+
+These IDs are shared vocabulary with `product-design`, which cites them when routing naming and state decisions here:
+
+- `rule/destructive-names-action`
+- `rule/no-confirm-ok-labels`
+- `rule/canonical-verb`
+- `rule/error-states-recovery`
+- `rule/empty-state-action`
+- `rule/loading-state-specific`
+
+Flag violations of these in edit mode with the `[STATE-COPY]` label.

--- a/skills/product-design/SKILL.md
+++ b/skills/product-design/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: product-design
+description: >-
+  Owns product and UX judgment and correctness: the right interaction, actions
+  named by object, scope, and consequence, coverage of every reachable state
+  (loading, empty, error, permission, partial, destructive, offline),
+  resilience, and accessibility as a product concern. Routes by request mode:
+  shape, implement, review, copy, harden. Cites stable rule IDs and defers to
+  the project's own design system and AGENTS.md. Use when asked "is this the
+  right interaction", "design the flow for", "what should this button do",
+  "name this action", "did we cover all the states", "review this UX decision",
+  "make this resilient", or "what breaks here". Not for visual direction or
+  building UI (use ui-design), page-level rendered-UI or accessibility audits
+  (use ui-audit), React or Next diff-level UX bug hunts (use ux-audit), or copy
+  wording and AI-ism removal (use copywriting).
+---
+
+# Product Design
+
+Make the interface correct for the user, the product, and the team. Working code is not enough: choose the right interaction, make scope and consequence clear, cover reality beyond the happy path, and verify the rendered result. This skill owns the decision of what should exist; it routes the visual build, the rendered audit, the code-level review, and the copy wording to the skills that own those.
+
+- **IS:** product and UX judgment on an intent, spec, mockup, or diff: choosing the right interaction and control, naming the object, scope, and consequence of actions, covering every reachable state, resilience, and accessibility as a product concern. It decides, then routes implementation out.
+- **IS NOT:**
+  - visual direction, palettes, type, or building UI in code: use `ui-design`.
+  - page-level rendered UI and accessibility-markup audits: use `ui-audit`.
+  - React or Next diff-level UX bug hunting with a ship verdict: use `ux-audit`.
+  - copy wording, persuasion, or AI-ism removal: use `copywriting`.
+  - deep typography or motion: use `typography-audit` or `ui-animation`.
+
+The line that prevents collapse into `ux-audit`: that skill reviews the *code* of a React diff and returns line-level fixes and a verdict. This skill reviews the *decision* (which control, what the action is named, which states are reachable) on any artifact, and hands the implementation to the owning skill.
+
+## Operating contract
+
+- Start with the job, not the pixels. Identify who is acting, what they want to accomplish, the object involved, and what the system will change.
+- Use evidence, not taste. Trace each decision to product behavior, canonical project guidance, an accepted decision, or a verified adjacent pattern.
+- Cite a stable rule ID for every finding or non-mechanical decision. Never invent an ID; if none fits, record a coverage gap.
+- The project's own design system and `AGENTS.md` outrank this skill's defaults. Defer to them.
+- Never restyle or rebuild. Decide, then route the build to `ui-design`.
+- Design every reachable state, not just the populated success case.
+- Verify the real surface. Source inspection establishes behavior; a rendered interface establishes visual and interaction quality. Never claim visual verification from code alone.
+- One mode per request. Resolve it from the user's verb before acting.
+
+## Request modes
+
+Resolve the mode from the user's verb and artifact, then load only that mode's references.
+
+| Mode | Dispatch when the user asks for | Load |
+|------|--------------------------------|------|
+| **shape** (default) | "design the flow for", "what control here", "how should this work", "is this the right pattern", a brief with no settled UI | `references/product-judgment.md`, `references/surfaces.md` |
+| **implement** | "wire up the right interaction", "make sure this covers the states", judgment applied to an in-progress build | `references/surfaces.md`, `references/naming-and-copy.md`; route the build to `ui-design` |
+| **review** | "review this for product correctness", "what's wrong with this UX decision", "audit this flow" | `references/interface-quality.md`, `references/rules.md` |
+| **copy** | "name this action", "what should this button or dialog say" | `references/naming-and-copy.md`; route wording to `copywriting` |
+| **harden** | "make this resilient", "what breaks here", error, permission, offline, and destructive paths | `references/surfaces.md`, `references/interface-quality.md` (Resilience) |
+
+Modes chain: shape leads into implement; review leads into harden. When intent is ambiguous, use the narrowest mode the verb supports. A URL, screenshot, route, or component identifies scope; it does not by itself authorize edits.
+
+A material decision changes the user's task, default, scope, consequence, navigation, interaction surface, or reachable states. Copy mechanics, token swaps, and established component substitutions usually are not material.
+
+## Decision authority
+
+Resolve conflicts in this order, highest first:
+
+1. The user's explicit goal and constraints.
+2. Verified user and product evidence, and what the system actually does.
+3. Project-canonical guidance: `AGENTS.md` or `CLAUDE.md`, the project's design system, and routed sibling skills.
+4. Sibling-skill ownership. Route, do not duplicate:
+   - visual direction and build: `ui-design`
+   - rendered quality and a11y-markup audit: `ui-audit`
+   - React or Next behavior review and verdict: `ux-audit`
+   - copy wording and AI-ism removal: `copywriting`
+5. This skill's product design standards (below).
+6. General interface and platform conventions.
+
+When a request spans authorities, name the owning skill and hand off rather than acting outside this skill's slice.
+
+## Workflow
+
+```
+Product design pass:
+- [ ] Step 1: Classify the request into exactly one mode
+- [ ] Step 2: Locate authority (user constraints, project design system, AGENTS.md)
+- [ ] Step 3: Load only that mode's reference files
+- [ ] Step 4: Identify the object, scope, and consequence of each action in scope
+- [ ] Step 5: Enumerate reachable states and check coverage (surfaces.md)
+- [ ] Step 6: Apply the standards; cite a stable rule ID per finding or decision
+- [ ] Step 7: Emit output (review and harden use P0-P3) and route follow-on work to siblings
+```
+
+For shape, implement, harden, or any material product or flow change, write the compact internal brief in `references/product-judgment.md` before proposing UI: user, job, current behavior, desired outcome, success signal, non-goals, object, action, consequence, reversibility, permissions, and open decisions.
+
+## Product design standards
+
+Five pillars. Each cites its governing rule IDs in `references/rules.md` and points to its reference.
+
+- **Right interaction.** Pick the control from the shape of the choice; keep options visible and reversible; prefer inline disclosure before a modal; choose the smallest coherent intervention. `rule/control-matches-cardinality`, `rule/navigation-vs-action`, `rule/inline-before-modal`, `rule/smallest-intervention`. See `references/product-judgment.md`.
+- **Action naming.** Name the object, scope, and consequence; destructive CTAs use Verb plus Noun, never "Confirm" or "OK"; make friction proportional to impact and offer undo when honest. `rule/name-object-scope-consequence`, `rule/destructive-names-action`, `rule/destructive-proportional`. See `references/naming-and-copy.md`.
+- **State coverage.** Design every reachable state, not just the populated one; empty states name the object and a first action; errors explain and offer recovery; preserve user input. `rule/cover-reachable-states`, `rule/empty-state-action`, `rule/error-states-recovery`, `rule/preserve-user-input`. See `references/surfaces.md`.
+- **Resilience.** Survive overflow, extreme data, localization and RTL, and network failure; every fetch lands in a designed state. See `references/interface-quality.md` (Resilience).
+- **Accessibility as a product concern.** Every control has an accessible name; the primary flow is completable by keyboard with visible focus; state and consequence are understandable, not just labeled. `rule/accessible-name-required`, `rule/keyboard-complete-flow`, `rule/no-custom-focus-bypass`. Route axe-style markup checks to `ui-audit`. See `references/interface-quality.md`.
+
+## Review output
+
+In review and harden modes, lead with findings ordered by user impact:
+
+- **P0:** blocks the primary task, a severe accessibility failure, or unrecoverable user harm (data loss, permission bypass, an unintelligible destructive action).
+- **P1:** likely task failure, a misleading consequence, a missing critical state, or a major responsive or accessibility defect.
+- **P2:** meaningful friction, inconsistency, weak hierarchy, or a recoverability issue.
+- **P3:** minor craft or consistency improvement.
+
+For each finding: location (file and line, or rendered location and viewport), verification status, the rule ID, the user consequence, and the smallest concrete fix with the skill that owns implementing it. Keep findings at the decision altitude; a line-level framework fix is `ux-audit`'s output, not this skill's. Full rubric in `references/interface-quality.md`.
+
+## Linters vs agent guidance
+
+Deterministic, structural, single-file checks belong in a linter; judgment that needs product context stays in this skill. This skill ships a real, installable ESLint plugin for the deterministic slice (control selection, nested modals, accessible names, design-system overrides, modal scroll, raw shadows, off-grid spacing). It is a working package with tests, not a snippet.
+
+See `references/lint/README.md` for the rules, the install and config, and the full "lint rule vs agent guidance" decision tree. Counting 2-3 static options is mechanical, so it is a lint rule; naming the right object and consequence needs product context, so it stays here.
+
+## Evals and the review loop
+
+Keep this skill calibrated. Evals test whether the guidance still produces the right edits on unseen interfaces; a weekly review loop gathers evidence and prepares guideline updates for human review. Both are recommended practice, not runtime behavior. See `references/evals/README.md` for the fixture shape, the judge rubric, and the collector, judge, and human-review loop.
+
+## Gotchas
+
+- Do not restyle or rebuild. That is `ui-design`. This skill decides, then routes.
+- Do not re-run `ux-audit`'s diff rules here. "Review this PR for UX bugs" goes to `ux-audit`; this skill reviews the decision, not the code, and returns no framework fix patches.
+- Do not invent rule IDs. Cite only IDs in `references/rules.md` (or, for copy, in `copywriting/references/ui-states.md`).
+- A mockup with only a happy path is a P1 minimum, not a pass (`rule/cover-reachable-states`).
+- The project's design system outranks this skill's defaults. Do not impose a pattern the project already decided against.
+- "Accessibility as a product concern" means keyboard-completable flows and understandable states, not axe-clean markup. Route the markup audit to `ui-audit`.
+- A select with two options is not a style nit; it is `rule/control-matches-cardinality`, and the lint rule catches it.
+
+## Related skills
+
+- `ui-design`: visual direction and building the decided interaction in code.
+- `ui-audit`: page-level rendered quality and accessibility-markup audit of the built result.
+- `ux-audit`: React or Next diff-level UX bug hunt with a ship verdict.
+- `copywriting`: the wording of names, errors, and empty and loading copy; defines the shared copy rule IDs in its `references/ui-states.md`.
+- `typography-audit`, `ui-animation`: type and motion.

--- a/skills/product-design/references/evals/README.md
+++ b/skills/product-design/references/evals/README.md
@@ -1,0 +1,71 @@
+# Evals and the Review Loop
+
+This is recommended calibration practice, not runtime skill behavior. It keeps `product-design` honest over time: the skill is only as good as the decisions encoded in it, and those decisions drift as components, names, and failure modes change. Two mechanisms keep it current: evals (does the guidance still produce the right edits?) and a review loop (what new evidence should change the guidance?).
+
+## Why evals
+
+Lint rules are deterministic, but agent behavior varies. Test the skill on interfaces it has not seen. An agent edits a `before` state, and a judge scores the result against the rubric (`rubric.md`).
+
+- Build training fixtures from documented examples (decisions you already accept).
+- Build holdouts from interfaces whose expected edits do not appear in the skill, to test whether the guidance generalizes rather than memorizes.
+- Run fixtures with and without the skill loaded, to measure whether the skill changed the agent's behavior at all.
+- Score rule correctness separately from similarity to a shipped result. Shipped code can contain a flaw the agent should improve, not reproduce.
+
+## Fixture shape
+
+Each fixture in `fixtures/` is a `before` and an `after` paired with the rules it exercises:
+
+```
+fixtures/
+  <name>/
+    before.jsx     # the starting interface, with a real product-design defect
+    after.jsx      # a correct resolution
+    notes.md       # the rule IDs exercised, and what the judge should check
+```
+
+Keep fixtures minimal and generic: one or two defects each, no framework or design-system specifics beyond plain JSX. Three are included as worked examples; add your own from real decisions.
+
+## The weekly review loop
+
+Standards change, and every change needs evidence and human review. Separate collection from judgment so neither contaminates the other.
+
+1. Collector. Gather messages, links, files, and nearby context from your team's review evidence (design-review threads, design files, pull requests, and previews are common sources). Write raw artifacts only. Do not score candidates or propose rules.
+2. Judge. Validate that the evidence is complete before grouping it. Group related items, verify each source, and separate verified facts from inferences and open questions. When evidence is incomplete, record the code or commit needed to verify it. Keep every candidate pending. Do not edit the guidance.
+3. Human review packet. The loop ends with a packet: candidates (each linked to its source), rejected topics, follow-up requests, and coverage gaps. A comment from an experienced reviewer can raise a candidate's priority, but every candidate still needs evidence.
+
+Automation ends at the packet. A human decides whether a candidate becomes agent guidance, a lint rule, an exemplar, an eval, or no change. Accepted changes go into the narrowest relevant file and pass the relevant checks before merging.
+
+### Prompts
+
+```
+Collector
+You are the collector. Gather messages, links, files, and nearby context.
+Write raw artifacts only. Do not score candidates or propose rules.
+
+Judge
+You are the judge. Validate coverage before grouping related evidence.
+Separate verified facts, inferences, and open questions. Keep every
+candidate pending. Do not edit the guidance.
+
+Human review
+Choose: rule, reference, exemplar, lint rule, eval, coverage gap, or no change.
+Require stable evidence, explicit scope and exceptions, and an approver.
+```
+
+## Coverage gaps
+
+Track decisions you do not yet have a standard for, so missing guidance stays visible instead of silently absent. A gap is a candidate for the next review, not a failure.
+
+Current gaps to seed your own list:
+- Multi-step flows and wizards: progress, back, and abandon behavior.
+- Bulk actions: selection model, partial success, and per-item error reporting.
+- Real-time and collaborative states: presence, conflict, and merge.
+- Notification and toast lifecycle: dismissal, stacking, and persistence.
+
+## Self-checks for any change to this skill
+
+- No em dashes anywhere (the source material uses them; strip on import).
+- Every cited rule ID exists in `../rules.md` (or, for copy IDs, in `copywriting/references/ui-states.md`).
+- New rules record scope, rationale, evidence, exceptions, and a bad and good example.
+- Deterministic checks went to the lint package; judgment stayed in prose with its evidence.
+- No single screenshot, shipped file, or reviewer comment was promoted into a universal rule by itself.

--- a/skills/product-design/references/evals/fixtures/destructive-confirm/after.jsx
+++ b/skills/product-design/references/evals/fixtures/destructive-confirm/after.jsx
@@ -1,0 +1,23 @@
+// The CTA names the object (Verb + Noun). The body states scope and consequence.
+// The dialog body scrolls so the actions stay reachable.
+export function DeleteProjectDialog({ project, onClose }) {
+  return (
+    <Modal onClose={onClose}>
+      <Modal.Header>Delete {project.name}?</Modal.Header>
+      <Modal.Body>
+        <p>
+          This permanently deletes {project.name} and its {project.deploymentCount}{' '}
+          deployments. This cannot be undone.
+        </p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="danger" onClick={() => deleteProject(project.id)}>
+          Delete project
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/skills/product-design/references/evals/fixtures/destructive-confirm/before.jsx
+++ b/skills/product-design/references/evals/fixtures/destructive-confirm/before.jsx
@@ -1,0 +1,16 @@
+// Defect: the destructive confirmation hides what it does behind "Confirm",
+// states no object/scope/consequence, and clears the form on a failed submit.
+export function DeleteProjectDialog({ project, onClose }) {
+  return (
+    <Modal onClose={onClose}>
+      <h2>Are you sure?</h2>
+      <p>This action cannot be undone.</p>
+      <Button variant="danger" onClick={() => deleteProject(project.id)}>
+        Confirm
+      </Button>
+      <Button variant="ghost" onClick={onClose}>
+        Cancel
+      </Button>
+    </Modal>
+  );
+}

--- a/skills/product-design/references/evals/fixtures/destructive-confirm/notes.md
+++ b/skills/product-design/references/evals/fixtures/destructive-confirm/notes.md
@@ -1,0 +1,14 @@
+# destructive-confirm
+
+Rule IDs exercised:
+- `rule/destructive-names-action`: "Confirm" must become Verb + Noun ("Delete project").
+- `rule/no-confirm-ok-labels`: no bare "Confirm"/"OK"/"Yes" on a destructive action.
+- `rule/name-object-scope-consequence`: the body must name the object, the scope (deployment count), and the consequence (permanent).
+- `rule/modal-body-scroll`: content belongs in a scrollable body so the footer actions stay reachable.
+
+Judge should check:
+- The primary destructive CTA names the object.
+- Scope and consequence are stated before the user commits.
+- The cancel path is preserved and not emphasized over delete.
+
+Do not credit a fix that renames the button but leaves the body as a generic "Are you sure?" with no scope or consequence.

--- a/skills/product-design/references/evals/fixtures/few-options-select/after.jsx
+++ b/skills/product-design/references/evals/fixtures/few-options-select/after.jsx
@@ -1,0 +1,16 @@
+// Three static options shown at once as radios, so the user compares without
+// opening a menu. Each option carries the consequence of the choice.
+export function VisibilityField({ value, onChange }) {
+  return (
+    <RadioGroup
+      label="Visibility"
+      value={value}
+      onChange={onChange}
+      options={[
+        { value: 'private', label: 'Private', hint: 'Only you' },
+        { value: 'team', label: 'Team', hint: 'Everyone in your team' },
+        { value: 'public', label: 'Public', hint: 'Anyone with the link' },
+      ]}
+    />
+  );
+}

--- a/skills/product-design/references/evals/fixtures/few-options-select/before.jsx
+++ b/skills/product-design/references/evals/fixtures/few-options-select/before.jsx
@@ -1,0 +1,14 @@
+// Defect: three static, mutually exclusive options hidden behind a select that
+// requires a click to open and compare.
+export function VisibilityField({ value, onChange }) {
+  return (
+    <label>
+      Visibility
+      <Select value={value} onChange={onChange}>
+        <option value="private">Private</option>
+        <option value="team">Team</option>
+        <option value="public">Public</option>
+      </Select>
+    </label>
+  );
+}

--- a/skills/product-design/references/evals/fixtures/few-options-select/notes.md
+++ b/skills/product-design/references/evals/fixtures/few-options-select/notes.md
@@ -1,0 +1,16 @@
+# few-options-select
+
+Rule IDs exercised:
+- `rule/control-matches-cardinality`: 2-3 static, mutually exclusive options use radios or a segmented control, not a select.
+
+This fixture is also covered deterministically by the lint rule
+`prefer-radio-for-few-options`. It appears here to test that the agent makes the
+same call from judgment, and that it carries the consequence of each option
+(who can see it) rather than just relabeling the control.
+
+Judge should check:
+- The select became a visible-options control (radios or segmented).
+- Each option communicates its consequence.
+
+Do not credit converting to radios if the options become dynamic or exceed a
+small static set, where a select is the right call.

--- a/skills/product-design/references/evals/fixtures/missing-states/after.jsx
+++ b/skills/product-design/references/evals/fixtures/missing-states/after.jsx
@@ -1,0 +1,33 @@
+// Every reachable state is designed: loading, error with a retry, empty with a
+// first action, and populated. Input and context are preserved across each.
+export function MemberList({ members, status, onRetry, onInvite }) {
+  if (status === 'loading') return <MemberListSkeleton />;
+
+  if (status === 'error') {
+    return (
+      <EmptyState
+        title="Could not load members"
+        description="Check your connection and try again."
+        action={<Button onClick={onRetry}>Retry</Button>}
+      />
+    );
+  }
+
+  if (members.length === 0) {
+    return (
+      <EmptyState
+        title="No members yet"
+        description="Invite a teammate to start collaborating."
+        action={<Button onClick={onInvite}>Invite member</Button>}
+      />
+    );
+  }
+
+  return (
+    <ul>
+      {members.map((member) => (
+        <li key={member.id}>{member.name}</li>
+      ))}
+    </ul>
+  );
+}

--- a/skills/product-design/references/evals/fixtures/missing-states/before.jsx
+++ b/skills/product-design/references/evals/fixtures/missing-states/before.jsx
@@ -1,0 +1,12 @@
+// Defect: only the populated success state is designed. Loading shows nothing,
+// an empty list renders a bare string with no next action, and a failed fetch
+// is not handled at all.
+export function MemberList({ members }) {
+  return (
+    <ul>
+      {members.map((member) => (
+        <li key={member.id}>{member.name}</li>
+      ))}
+    </ul>
+  );
+}

--- a/skills/product-design/references/evals/fixtures/missing-states/notes.md
+++ b/skills/product-design/references/evals/fixtures/missing-states/notes.md
@@ -1,0 +1,16 @@
+# missing-states
+
+Rule IDs exercised:
+- `rule/cover-reachable-states`: loading, empty, error, and populated are all reachable and must be designed.
+- `rule/empty-state-action`: the empty state names the object and offers the first action (invite), not a dead-end string.
+- `rule/error-states-recovery`: the error state explains and offers a recovery (retry), with no raw exception text.
+
+Judge should check:
+- At least loading, empty, error, and populated are handled.
+- The empty state distinguishes never-had-any (onboarding) from a failure.
+- The error path offers recovery.
+
+This is a holdout-style fixture: it has no single "shipped" reference to copy.
+Score on whether the reachable states are covered, not on matching this exact
+markup. A pass that adds loading and empty but silently drops the error path is
+Partial, not Pass.

--- a/skills/product-design/references/evals/rubric.md
+++ b/skills/product-design/references/evals/rubric.md
@@ -1,0 +1,40 @@
+# Judge Rubric
+
+Score a `product-design` pass on a fixture. The judge compares the agent's `after` to the defect in `before` and the rule IDs in `notes.md`. Score the two dimensions separately; do not average them into one number.
+
+## Dimension 1: rule correctness (primary)
+
+Did the agent make the right product decision, by the rules, regardless of whether it matches the reference `after`?
+
+| Score | Meaning |
+|-------|---------|
+| Pass | Every defect named in `notes.md` is resolved correctly, and no new defect was introduced. Cites the right rule IDs. |
+| Partial | The main defect is resolved but a secondary one is missed, or the fix is correct but the reasoning cites the wrong or no rule ID. |
+| Fail | The main defect is unresolved, misdiagnosed, or a new defect was introduced. |
+
+A `before` may contain more than one defect. Credit only defects actually fixed; do not give credit for plausible-looking changes that miss the named issue.
+
+## Dimension 2: similarity to reference (secondary)
+
+How close is the `after` to the reference resolution? This is informational, not the score. A correct fix that differs from the reference is still correct. A fix that matches the reference but reproduces a flaw the reference contained is still wrong on Dimension 1.
+
+| Score | Meaning |
+|-------|---------|
+| High | Substantially the same resolution as the reference. |
+| Medium | A different but valid resolution. |
+| Low | Diverges from the reference; judge on Dimension 1 alone. |
+
+## Scope discipline checks
+
+Penalize on Dimension 1 if the agent:
+
+- Restyled or rebuilt visuals instead of routing that to `ui-design`.
+- Wrote line-level framework fix patches instead of decision-level findings (that is `ux-audit`'s job).
+- Broadened a copy pass into a redesign, or an audit into edits, without being asked.
+- Added configuration or new UI where a better default would have solved the job (`rule/smallest-intervention`).
+
+## Self-check
+
+- The pass introduces no em dashes.
+- Every rule ID cited by the agent exists in `../rules.md` or `copywriting/references/ui-states.md`.
+- Findings name a user consequence, not just a code change.

--- a/skills/product-design/references/interface-quality.md
+++ b/skills/product-design/references/interface-quality.md
@@ -1,0 +1,71 @@
+# Interface Quality
+
+Load in `review` and `harden` modes, and for any material visual change. This file holds the correctness and resilience standards and the severity rubric used to report findings. It does not cover visual aesthetics (route to `ui-design`) or rendered-markup audits (route to `ui-audit`).
+
+## Verify the real surface
+
+Source inspection establishes behavior; a rendered interface establishes visual and interaction quality. Never claim visual verification from code alone. State which you did:
+
+- "Verified in source" means you read the component and traced the logic.
+- "Verified rendered" means you looked at the running interface at the stated viewport.
+
+A review that says "looks good" without naming which kind of verification happened is not a verification.
+
+## Standards
+
+### Correctness
+
+- The control matches the choice (`rule/control-matches-cardinality`) and the semantic matches the intent (`rule/navigation-vs-action`).
+- The primary task and action are unmistakable (`rule/one-primary-action`).
+- Important actions name their object, scope, and consequence (`rule/name-object-scope-consequence`).
+- User input survives validation and recoverable errors (`rule/preserve-user-input`).
+
+### Accessibility as a product concern
+
+This skill owns whether a user can complete the task with assistive technology, not the axe-style markup audit (that is `ui-audit`).
+
+- Every interactive control has an accessible name (`rule/accessible-name-required`).
+- The primary flow is completable by keyboard, with visible focus and sensible order (`rule/keyboard-complete-flow`).
+- Focus moves to new surfaces and returns on close; nothing traps the user.
+- Do not bypass the shared focus token with a custom ring (`rule/no-custom-focus-bypass`).
+- State and consequence are understandable, not just present: an error a screen reader announces as "error" with no detail fails this even if it is technically labeled.
+
+### Visual system integrity
+
+- Do not override a design-system component's color, radius, shadow, or focus via `className` (`rule/no-design-system-override`). Layout utilities are fine.
+- Use theme-aware materials over raw shadows; do not duplicate a material's border (`rule/material-over-raw-shadow`).
+- Keep spacing on the grid (`rule/spacing-on-grid`).
+- Group with hierarchy before containers (`rule/structure-before-containers`).
+
+Route the taste-level visual decision (palette, type scale, polish) to `ui-design`. This skill checks that the system is used correctly, not whether the result is beautiful.
+
+## Resilience
+
+The interface must survive reality beyond the demo data.
+
+- Overflow: long names, long labels, and long single words do not break layout or clip silently. Truncate with intent and a way to see the full value.
+- Extreme data: very large counts, very long lists, zero, and negative or boundary values render without breaking alignment or pagination.
+- Localization and RTL: translated strings are longer; layouts that assume English width break. Mirror correctly under RTL.
+- Network and error: every fetch can fail or hang. Slow, offline, and partial responses each land in a designed state (`surfaces.md`), not a blank screen or an infinite spinner.
+- Time and timezone: relative times and date formatting do not assume the viewer's locale silently.
+
+A surface that only works with short English strings and fast, successful responses is not resilient; it is a demo.
+
+## Severity rubric
+
+Report findings ordered by user impact. Use these levels exactly.
+
+- P0: blocks the primary task, creates a severe accessibility failure, or can cause unrecoverable user harm (data loss, a permission bypass, a destructive action the user cannot understand or undo).
+- P1: likely task failure, a misleading consequence, a missing critical state, or a major responsive or accessibility defect.
+- P2: meaningful friction, inconsistency, weak hierarchy, or a recoverability issue that does not block the task.
+- P3: minor craft or consistency improvement.
+
+For each finding include:
+
+- Location: file and line for source findings, or the rendered location and viewport.
+- Verification status: verified in source, verified rendered, or unverified (and why).
+- Rule ID: the `rule/` slug it violates.
+- User consequence: what goes wrong for the user, not just what the code does.
+- Smallest concrete fix: the narrowest change that resolves it, and which skill owns implementing it.
+
+Keep findings at the decision altitude. Naming the wrong control, the missing error state, or the unnamed destructive action is this skill's job. A line-level React bug with a code patch is `ux-audit`'s job; hand it over rather than writing the fix here.

--- a/skills/product-design/references/lint/README.md
+++ b/skills/product-design/references/lint/README.md
@@ -1,0 +1,60 @@
+# eslint-plugin-product-design
+
+A small, real ESLint plugin that enforces the deterministic slice of `product-design`: the rules a linter can check reliably from a single file's AST, without rendering and without product context. Judgment-level rules stay in the skill; these seven do not need a human.
+
+This is a working package, not a snippet. It installs, it runs, and its rules are covered by tests.
+
+## Rules
+
+| Rule | Rule ID | Default | What it catches |
+|------|---------|---------|-----------------|
+| `prefer-radio-for-few-options` | `rule/control-matches-cardinality` | warn | A select with 2-3 static options that should be radios |
+| `no-nested-modals` | `rule/no-nested-modals` | error | A modal opened inside another modal |
+| `icon-button-accessible-name` | `rule/accessible-name-required` | error | An icon-only button with no accessible name |
+| `no-design-system-override` | `rule/no-design-system-override` | off | `className` overriding a design-system component's color, radius, or shadow |
+| `require-modal-body` | `rule/modal-body-scroll` | warn | A modal with content but no scrollable body container |
+| `no-raw-shadow` | `rule/material-over-raw-shadow` | warn | Raw `shadow-*` utilities instead of theme-aware materials |
+| `off-grid-spacing` | `rule/spacing-on-grid` | warn | Arbitrary spacing utilities off the 4px grid |
+
+`no-design-system-override` ships off because it cannot know which elements are yours. Turn it on by listing your components (see the example config). Every rule takes options so it points at your design system, not a hardcoded one.
+
+## Install and wire up
+
+```bash
+npm install --save-dev eslint-plugin-product-design eslint
+```
+
+Then either take the preset or configure per rule. See `eslint.config.example.js` for both forms. Formatting belongs to a faster tool: run oxfmt (oxlint) or Biome for format, and let ESLint own these JSX-semantic rules. They do not overlap.
+
+## Run the tests
+
+```bash
+npm install
+npm test
+```
+
+`npm test` runs `node --test` over `tests/rules.test.js`, which exercises each rule with valid and invalid cases through ESLint's `RuleTester`. This is the proof the rules run, and the regression net when you change one.
+
+## Lint rule vs agent guidance: the decision tree
+
+Use this to decide where a new product-design standard belongs. The goal is to keep deterministic checks mechanical and keep judgment in the skill with its evidence.
+
+```
+Can code identify the failure from one file's AST, without rendering?
+  No  -> agent guidance (the product-design skill).
+  Yes -> Can the rule avoid likely false positives?
+           No  -> agent guidance.
+           Yes -> Does the violation have a concrete, mechanical fix?
+                    Yes -> a lint rule (add it here).
+                    No  -> a warning, or agent guidance.
+
+Needs product or codebase context (which object, what consequence)?  -> agent guidance.
+Establishes a new standard or product policy?                          -> human decision first.
+```
+
+For either path, add a test or eval that can catch the regression. If a rule cannot stay reliable without many exceptions, move it back to agent guidance.
+
+Examples of the split:
+- Counting 2-3 static options is mechanical, so `prefer-radio-for-few-options` is a lint rule.
+- Naming the right object and consequence for a destructive action needs product context, so it stays in the skill (`rule/name-object-scope-consequence`) and in `copywriting` for the wording.
+- Detecting a nested modal is structural, so it is a lint rule. Deciding whether the second step should exist at all is judgment.

--- a/skills/product-design/references/lint/eslint.config.example.js
+++ b/skills/product-design/references/lint/eslint.config.example.js
@@ -1,0 +1,48 @@
+// Drop-in flat config showing how to wire eslint-plugin-product-design into a
+// consuming app. Copy the relevant block into your own eslint.config.js.
+//
+// Formatting is a separate, faster concern: run oxfmt (oxlint) or Biome for
+// format and let ESLint own these JSX-semantic rules. They do not overlap.
+
+const productDesign = require('eslint-plugin-product-design');
+
+module.exports = [
+  // Option A: take the recommended preset as-is.
+  productDesign.configs.recommended,
+
+  // Option B: configure rules to your own design system. This block overrides
+  // the preset for your component files. Replace the component names with yours.
+  {
+    files: ['**/*.{jsx,tsx}'],
+    plugins: { 'product-design': productDesign },
+    rules: {
+      'product-design/prefer-radio-for-few-options': [
+        'warn',
+        { selectComponents: ['Select'], optionComponents: ['Select.Option'] },
+      ],
+      'product-design/no-nested-modals': [
+        'error',
+        { modalComponents: ['Modal', 'Dialog', 'Sheet'] },
+      ],
+      'product-design/icon-button-accessible-name': [
+        'error',
+        { buttonComponents: ['button', 'Button', 'IconButton'] },
+      ],
+      // Turn this on by naming your design-system components and the visual
+      // utilities they own. Layout utilities (m-, p-, w-, grid) stay allowed.
+      'product-design/no-design-system-override': [
+        'warn',
+        {
+          components: ['Button', 'Card', 'Badge', 'Input'],
+          forbiddenPatterns: ['^bg-', '^rounded', '^shadow', '^ring-'],
+        },
+      ],
+      'product-design/require-modal-body': [
+        'warn',
+        { modalComponents: ['Modal', 'Dialog'], bodyComponent: 'Body' },
+      ],
+      'product-design/no-raw-shadow': 'warn',
+      'product-design/off-grid-spacing': ['warn', { gridBase: 4 }],
+    },
+  },
+];

--- a/skills/product-design/references/lint/index.js
+++ b/skills/product-design/references/lint/index.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const rules = {
+  'prefer-radio-for-few-options': require('./rules/prefer-radio-for-few-options'),
+  'no-nested-modals': require('./rules/no-nested-modals'),
+  'icon-button-accessible-name': require('./rules/icon-button-accessible-name'),
+  'no-design-system-override': require('./rules/no-design-system-override'),
+  'require-modal-body': require('./rules/require-modal-body'),
+  'no-raw-shadow': require('./rules/no-raw-shadow'),
+  'off-grid-spacing': require('./rules/off-grid-spacing'),
+};
+
+const plugin = {
+  meta: { name: 'eslint-plugin-product-design', version: '0.1.0' },
+  rules,
+};
+
+// Flat-config preset. `no-design-system-override` ships off because it needs
+// your component list to do anything; turn it on with options once configured.
+plugin.configs = {
+  recommended: {
+    plugins: { 'product-design': plugin },
+    rules: {
+      'product-design/prefer-radio-for-few-options': 'warn',
+      'product-design/no-nested-modals': 'error',
+      'product-design/icon-button-accessible-name': 'error',
+      'product-design/no-design-system-override': 'off',
+      'product-design/require-modal-body': 'warn',
+      'product-design/no-raw-shadow': 'warn',
+      'product-design/off-grid-spacing': 'warn',
+    },
+  },
+};
+
+module.exports = plugin;

--- a/skills/product-design/references/lint/package-lock.json
+++ b/skills/product-design/references/lint/package-lock.json
@@ -1,0 +1,1102 @@
+{
+  "name": "eslint-plugin-product-design",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eslint-plugin-product-design",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^9.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/skills/product-design/references/lint/package.json
+++ b/skills/product-design/references/lint/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "eslint-plugin-product-design",
+  "version": "0.1.0",
+  "description": "Deterministic product-design lint rules: control selection, nested modals, accessible names, design-system overrides, modal scroll, raw shadows, and off-grid spacing.",
+  "type": "commonjs",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js"
+  },
+  "files": [
+    "index.js",
+    "rules"
+  ],
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "product-design",
+    "accessibility",
+    "design-system"
+  ],
+  "peerDependencies": {
+    "eslint": ">=8.40.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.0.0"
+  },
+  "license": "MIT"
+}

--- a/skills/product-design/references/lint/rules/icon-button-accessible-name.js
+++ b/skills/product-design/references/lint/rules/icon-button-accessible-name.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * rule/accessible-name-required
+ * An icon-only button with no accessible name is unusable by screen readers
+ * and ambiguous under load.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Require an accessible name on icon-only buttons',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          buttonComponents: { type: 'array', items: { type: 'string' } },
+          nameProps: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      needsName:
+        'Icon-only button has no accessible name. Add a visible label, aria-label, or title (rule/accessible-name-required).',
+    },
+  },
+  create(context) {
+    const opts = context.options[0] || {};
+    const buttonComponents = opts.buttonComponents || [
+      'button',
+      'Button',
+      'IconButton',
+    ];
+    const nameProps = opts.nameProps || ['aria-label', 'aria-labelledby', 'title'];
+
+    return {
+      JSXElement(node) {
+        const name = node.openingElement.name;
+        if (name.type !== 'JSXIdentifier' || !buttonComponents.includes(name.name)) {
+          return;
+        }
+
+        const attrs = node.openingElement.attributes;
+        const hasNameProp = attrs.some(
+          (attr) =>
+            attr.type === 'JSXAttribute' &&
+            attr.name.type === 'JSXIdentifier' &&
+            nameProps.includes(attr.name.name),
+        );
+        if (hasNameProp) return;
+
+        // Ignore whitespace-only text children; keep real text, elements, expressions.
+        const children = node.children.filter(
+          (child) => !(child.type === 'JSXText' && child.value.trim() === ''),
+        );
+
+        // Empty button with no name, or a button whose only children are icon
+        // elements (no text), is icon-only. A dynamic child ({label}) might be
+        // text, so bail to avoid false positives.
+        if (children.length === 0) {
+          context.report({ node: node.openingElement, messageId: 'needsName' });
+          return;
+        }
+        if (children.some((child) => child.type === 'JSXExpressionContainer')) {
+          return;
+        }
+        if (children.every((child) => child.type === 'JSXElement')) {
+          context.report({ node: node.openingElement, messageId: 'needsName' });
+        }
+      },
+    };
+  },
+};

--- a/skills/product-design/references/lint/rules/no-design-system-override.js
+++ b/skills/product-design/references/lint/rules/no-design-system-override.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * rule/no-design-system-override
+ * Overriding a design-system component's color, radius, shadow, or focus via
+ * className forks the system and breaks theming. Layout utilities are allowed.
+ *
+ * Requires configuration: list your design-system components in `components`.
+ * Without it, the rule is inert (it cannot know which elements are yours).
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Disallow className overriding a design-system component's color, radius, or shadow",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          components: { type: 'array', items: { type: 'string' } },
+          classProps: { type: 'array', items: { type: 'string' } },
+          forbiddenPatterns: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      override:
+        'className overrides the design system on <{{component}}>: {{classes}}. Use the component API or a design token, not a per-instance override (rule/no-design-system-override).',
+    },
+  },
+  create(context) {
+    const opts = context.options[0] || {};
+    const components = opts.components || [];
+    if (components.length === 0) return {};
+
+    const classProps = opts.classProps || ['className', 'class'];
+    const patterns = (
+      opts.forbiddenPatterns || [
+        '^bg-',
+        '^rounded',
+        '^shadow',
+        '^ring-',
+        '^border-[a-z]+-\\d',
+      ]
+    ).map((source) => new RegExp(source));
+
+    return {
+      JSXOpeningElement(node) {
+        if (node.name.type !== 'JSXIdentifier' || !components.includes(node.name.name)) {
+          return;
+        }
+        const classAttr = node.attributes.find(
+          (attr) =>
+            attr.type === 'JSXAttribute' &&
+            attr.name.type === 'JSXIdentifier' &&
+            classProps.includes(attr.name.name),
+        );
+        // Only static string class lists are checked.
+        if (!classAttr || !classAttr.value || classAttr.value.type !== 'Literal') {
+          return;
+        }
+        const tokens = String(classAttr.value.value).split(/\s+/).filter(Boolean);
+        const offenders = tokens.filter((token) =>
+          patterns.some((re) => re.test(token)),
+        );
+        if (offenders.length === 0) return;
+
+        context.report({
+          node: classAttr,
+          messageId: 'override',
+          data: { component: node.name.name, classes: offenders.join(', ') },
+        });
+      },
+    };
+  },
+};

--- a/skills/product-design/references/lint/rules/no-nested-modals.js
+++ b/skills/product-design/references/lint/rules/no-nested-modals.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * rule/no-nested-modals
+ * A modal opened from within a modal breaks focus trapping, escape-key order,
+ * and layering, and hides the original context.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow a modal nested inside another modal',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          modalComponents: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      noNested:
+        'Modal nested inside another modal. Resolve the first, use a single multi-step surface, or move the second step inline (rule/no-nested-modals).',
+    },
+  },
+  create(context) {
+    const opts = context.options[0] || {};
+    const modalComponents = opts.modalComponents || ['Modal', 'Dialog'];
+    let depth = 0;
+
+    function isModal(node) {
+      const name = node.openingElement.name;
+      return name.type === 'JSXIdentifier' && modalComponents.includes(name.name);
+    }
+
+    return {
+      JSXElement(node) {
+        if (!isModal(node)) return;
+        if (depth > 0) {
+          context.report({ node: node.openingElement, messageId: 'noNested' });
+        }
+        depth += 1;
+      },
+      'JSXElement:exit'(node) {
+        if (isModal(node)) depth -= 1;
+      },
+    };
+  },
+};

--- a/skills/product-design/references/lint/rules/no-raw-shadow.js
+++ b/skills/product-design/references/lint/rules/no-raw-shadow.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * rule/material-over-raw-shadow
+ * Raw shadow utilities ignore the theme and break in dark mode. Use the design
+ * system's theme-aware surface or material classes instead.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow raw shadow utilities in favor of theme-aware materials',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          classProps: { type: 'array', items: { type: 'string' } },
+          allow: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      rawShadow:
+        'Raw shadow utility: {{classes}}. Use a theme-aware surface or material class so elevation follows the theme (rule/material-over-raw-shadow).',
+    },
+  },
+  create(context) {
+    const opts = context.options[0] || {};
+    const classProps = opts.classProps || ['className', 'class'];
+    const allow = opts.allow || ['shadow-none'];
+
+    return {
+      JSXAttribute(node) {
+        if (
+          node.name.type !== 'JSXIdentifier' ||
+          !classProps.includes(node.name.name)
+        ) {
+          return;
+        }
+        if (!node.value || node.value.type !== 'Literal') return;
+
+        const tokens = String(node.value.value).split(/\s+/).filter(Boolean);
+        const raw = tokens.filter(
+          (token) => /^shadow(-|$)/.test(token) && !allow.includes(token),
+        );
+        if (raw.length === 0) return;
+
+        context.report({
+          node,
+          messageId: 'rawShadow',
+          data: { classes: raw.join(', ') },
+        });
+      },
+    };
+  },
+};

--- a/skills/product-design/references/lint/rules/off-grid-spacing.js
+++ b/skills/product-design/references/lint/rules/off-grid-spacing.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const SPACING_PREFIXES = [
+  'p', 'px', 'py', 'pt', 'pr', 'pb', 'pl',
+  'm', 'mx', 'my', 'mt', 'mr', 'mb', 'ml',
+  'gap', 'gap-x', 'gap-y', 'space-x', 'space-y',
+  'inset', 'inset-x', 'inset-y', 'top', 'right', 'bottom', 'left',
+];
+
+/**
+ * rule/spacing-on-grid
+ * Arbitrary spacing values that fall off the grid (commonly 4px) read as visual
+ * noise. Flag off-grid arbitrary utilities and prefer a standard one.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Flag arbitrary spacing utilities that fall off the spacing grid',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          classProps: { type: 'array', items: { type: 'string' } },
+          gridBase: { type: 'number', minimum: 1 },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      offGrid:
+        'Off-grid spacing: {{classes}}. Use a value that is a multiple of {{base}}px, or a standard spacing utility (rule/spacing-on-grid).',
+    },
+  },
+  create(context) {
+    const opts = context.options[0] || {};
+    const classProps = opts.classProps || ['className', 'class'];
+    const gridBase = opts.gridBase || 4;
+
+    return {
+      JSXAttribute(node) {
+        if (
+          node.name.type !== 'JSXIdentifier' ||
+          !classProps.includes(node.name.name)
+        ) {
+          return;
+        }
+        if (!node.value || node.value.type !== 'Literal') return;
+
+        const tokens = String(node.value.value).split(/\s+/).filter(Boolean);
+        const offenders = [];
+        for (const token of tokens) {
+          const match = token.match(/^(-?[a-z][a-z-]*?)-\[(\d+(?:\.\d+)?)px\]$/);
+          if (!match) continue;
+          const prefix = match[1].replace(/^-/, '');
+          if (!SPACING_PREFIXES.includes(prefix)) continue;
+          const px = parseFloat(match[2]);
+          if (px % gridBase !== 0) offenders.push(token);
+        }
+        if (offenders.length === 0) return;
+
+        context.report({
+          node,
+          messageId: 'offGrid',
+          data: { classes: offenders.join(', '), base: String(gridBase) },
+        });
+      },
+    };
+  },
+};

--- a/skills/product-design/references/lint/rules/prefer-radio-for-few-options.js
+++ b/skills/product-design/references/lint/rules/prefer-radio-for-few-options.js
@@ -1,0 +1,71 @@
+'use strict';
+
+/**
+ * rule/control-matches-cardinality
+ * Suggest radio buttons (or a segmented control) when a select renders only
+ * 2-3 static, mutually exclusive options, so every choice stays visible.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Suggest radio buttons when a select has a small number of static options',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          selectComponents: { type: 'array', items: { type: 'string' } },
+          optionComponents: { type: 'array', items: { type: 'string' } },
+          min: { type: 'integer', minimum: 1 },
+          max: { type: 'integer', minimum: 1 },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferRadio:
+        'Select with {{count}} static options. Consider radio buttons or a segmented control so every choice stays visible without a click (rule/control-matches-cardinality).',
+    },
+  },
+  create(context) {
+    const opts = context.options[0] || {};
+    const selectComponents = opts.selectComponents || ['Select', 'select'];
+    const optionComponents = opts.optionComponents || ['option', 'Option'];
+    const min = opts.min || 2;
+    const max = opts.max || 3;
+
+    return {
+      JSXElement(node) {
+        const name = node.openingElement.name;
+        if (name.type !== 'JSXIdentifier' || !selectComponents.includes(name.name)) {
+          return;
+        }
+        // Bail on any dynamically rendered children (a map, a spread, a variable):
+        // the option count is not statically known and the suggestion would misfire.
+        const hasDynamic = node.children.some(
+          (child) => child.type === 'JSXExpressionContainer',
+        );
+        if (hasDynamic) return;
+
+        const options = node.children.filter(
+          (child) =>
+            child.type === 'JSXElement' &&
+            child.openingElement.name.type === 'JSXIdentifier' &&
+            optionComponents.includes(child.openingElement.name.name),
+        );
+        if (options.length < min || options.length > max) return;
+
+        context.report({
+          node: node.openingElement,
+          messageId: 'preferRadio',
+          data: { count: String(options.length) },
+        });
+      },
+    };
+  },
+};

--- a/skills/product-design/references/lint/rules/require-modal-body.js
+++ b/skills/product-design/references/lint/rules/require-modal-body.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * rule/modal-body-scroll
+ * Long modal content needs a scroll container (for example Modal.Body) so the
+ * body scrolls while header and footer stay reachable. Without it, content
+ * pushes the actions off-screen.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Require a scrollable body container inside a modal with content',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          modalComponents: { type: 'array', items: { type: 'string' } },
+          bodyComponent: { type: 'string' },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      needsBody:
+        'Modal has content but no scrollable body container. Wrap content in {{body}} so it scrolls and the actions stay reachable (rule/modal-body-scroll).',
+    },
+  },
+  create(context) {
+    const opts = context.options[0] || {};
+    const modalComponents = opts.modalComponents || ['Modal', 'Dialog'];
+    const bodyComponent = opts.bodyComponent || 'Body';
+
+    function nameMatchesBody(jsxName, modalName) {
+      if (jsxName.type === 'JSXMemberExpression') {
+        return (
+          jsxName.property.type === 'JSXIdentifier' &&
+          jsxName.property.name === bodyComponent
+        );
+      }
+      if (jsxName.type === 'JSXIdentifier') {
+        return (
+          jsxName.name === bodyComponent || jsxName.name === modalName + bodyComponent
+        );
+      }
+      return false;
+    }
+
+    function hasBodyDescendant(node, modalName) {
+      for (const child of node.children || []) {
+        if (child.type !== 'JSXElement') continue;
+        if (nameMatchesBody(child.openingElement.name, modalName)) return true;
+        if (hasBodyDescendant(child, modalName)) return true;
+      }
+      return false;
+    }
+
+    return {
+      JSXElement(node) {
+        const name = node.openingElement.name;
+        if (name.type !== 'JSXIdentifier' || !modalComponents.includes(name.name)) {
+          return;
+        }
+        const hasElementChild = node.children.some(
+          (child) => child.type === 'JSXElement',
+        );
+        if (!hasElementChild) return; // empty modal, nothing to scroll
+        if (hasBodyDescendant(node, name.name)) return;
+
+        context.report({
+          node: node.openingElement,
+          messageId: 'needsBody',
+          data: { body: `${name.name}.${bodyComponent}` },
+        });
+      },
+    };
+  },
+};

--- a/skills/product-design/references/lint/tests/rules.test.js
+++ b/skills/product-design/references/lint/tests/rules.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const test = require('node:test');
+const { RuleTester } = require('eslint');
+
+// Run RuleTester synchronously under `node --test`: each call throws on the
+// first failing case, which fails the enclosing node:test.
+RuleTester.describe = function (text, fn) {
+  return fn.call(this);
+};
+RuleTester.it = function (text, fn) {
+  return fn.call(this);
+};
+RuleTester.itOnly = function (text, fn) {
+  return fn.call(this);
+};
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+const load = (name) => require(`../rules/${name}`);
+
+test('prefer-radio-for-few-options', () => {
+  ruleTester.run('prefer-radio-for-few-options', load('prefer-radio-for-few-options'), {
+    valid: [
+      {
+        code: '<Select><option>a</option><option>b</option><option>c</option><option>d</option></Select>',
+      },
+      { code: '<Select>{items.map((i) => <option>{i}</option>)}</Select>' },
+      { code: '<div><option>a</option><option>b</option></div>' },
+    ],
+    invalid: [
+      {
+        code: '<Select><option>a</option><option>b</option></Select>',
+        errors: [{ messageId: 'preferRadio' }],
+      },
+      {
+        code: '<Select><option>a</option><option>b</option><option>c</option></Select>',
+        errors: [{ messageId: 'preferRadio' }],
+      },
+    ],
+  });
+});
+
+test('no-nested-modals', () => {
+  ruleTester.run('no-nested-modals', load('no-nested-modals'), {
+    valid: [
+      { code: '<Modal><Modal.Body>content</Modal.Body></Modal>' },
+      { code: '<><Modal>a</Modal><Modal>b</Modal></>' },
+    ],
+    invalid: [
+      {
+        code: '<Modal><Modal>inner</Modal></Modal>',
+        errors: [{ messageId: 'noNested' }],
+      },
+      {
+        code: '<Dialog><div><Dialog>inner</Dialog></div></Dialog>',
+        errors: [{ messageId: 'noNested' }],
+      },
+    ],
+  });
+});
+
+test('icon-button-accessible-name', () => {
+  ruleTester.run('icon-button-accessible-name', load('icon-button-accessible-name'), {
+    valid: [
+      { code: '<button aria-label="Close"><Icon /></button>' },
+      { code: '<Button>Save changes</Button>' },
+      { code: '<button>{label}</button>' },
+      { code: '<IconButton title="Edit"><EditIcon /></IconButton>' },
+    ],
+    invalid: [
+      { code: '<button><Icon /></button>', errors: [{ messageId: 'needsName' }] },
+      { code: '<IconButton><svg /></IconButton>', errors: [{ messageId: 'needsName' }] },
+      { code: '<button></button>', errors: [{ messageId: 'needsName' }] },
+    ],
+  });
+});
+
+test('no-design-system-override', () => {
+  ruleTester.run('no-design-system-override', load('no-design-system-override'), {
+    valid: [
+      {
+        code: '<Button className="mt-4 w-full">Save</Button>',
+        options: [{ components: ['Button'] }],
+      },
+      { code: '<div className="bg-red-500 rounded-full">x</div>', options: [{ components: ['Button'] }] },
+      { code: '<Button className="bg-red-500">x</Button>' },
+    ],
+    invalid: [
+      {
+        code: '<Button className="bg-red-500 rounded-full shadow-lg mt-4">x</Button>',
+        options: [{ components: ['Button'] }],
+        errors: [{ messageId: 'override' }],
+      },
+    ],
+  });
+});
+
+test('require-modal-body', () => {
+  ruleTester.run('require-modal-body', load('require-modal-body'), {
+    valid: [
+      { code: '<Modal><Modal.Body><p>content</p></Modal.Body></Modal>' },
+      { code: '<Modal />' },
+      { code: '<Dialog><Dialog.Body>x</Dialog.Body></Dialog>' },
+    ],
+    invalid: [
+      {
+        code: '<Modal><div>long content here</div></Modal>',
+        errors: [{ messageId: 'needsBody' }],
+      },
+    ],
+  });
+});
+
+test('no-raw-shadow', () => {
+  ruleTester.run('no-raw-shadow', load('no-raw-shadow'), {
+    valid: [
+      { code: '<div className="shadow-none p-4">x</div>' },
+      { code: '<div className="rounded-lg">x</div>' },
+    ],
+    invalid: [
+      { code: '<div className="shadow-lg">x</div>', errors: [{ messageId: 'rawShadow' }] },
+      { code: '<Card className="p-4 shadow">x</Card>', errors: [{ messageId: 'rawShadow' }] },
+    ],
+  });
+});
+
+test('off-grid-spacing', () => {
+  ruleTester.run('off-grid-spacing', load('off-grid-spacing'), {
+    valid: [
+      { code: '<div className="p-[16px] mt-[8px]">x</div>' },
+      { code: '<div className="p-4 gap-2">x</div>' },
+      { code: '<div className="w-[13px]">x</div>' },
+    ],
+    invalid: [
+      { code: '<div className="p-[13px]">x</div>', errors: [{ messageId: 'offGrid' }] },
+      { code: '<div className="mt-[7px] gap-[10px]">x</div>', errors: [{ messageId: 'offGrid' }] },
+    ],
+  });
+});

--- a/skills/product-design/references/naming-and-copy.md
+++ b/skills/product-design/references/naming-and-copy.md
@@ -1,0 +1,60 @@
+# Naming and Copy
+
+Load in `copy` mode and whenever an action needs a name. This file owns the product decision of what an action is and what it must communicate. It does not own the wording craft: persuasion, tone, AI-ism removal, and the full state-copy rules live in `copywriting`. Decide here; route the wording there.
+
+## The split with copywriting
+
+- `product-design` decides: which action exists, its object, its scope, and its consequence. Whether a destructive action needs naming at all, and what it affects.
+- `copywriting` writes: the exact words, the canonical verb, the error and empty and loading strings. The shared rule IDs (`rule/destructive-names-action`, `rule/canonical-verb`, `rule/error-states-recovery`, `rule/empty-state-action`, `rule/loading-state-specific`) are defined in `copywriting/references/ui-states.md` and cited from here.
+
+When a request is "name this action" with a settled product decision, you can name it inline using the rules below. When it expands into rewriting many strings, tone, or persuasion, route to `copywriting`.
+
+## Object, scope, consequence
+
+Before naming an action, identify three things (`rule/name-object-scope-consequence`):
+
+- Object: the exact product noun. Not "this", but "the project", "3 members", "your API key".
+- Scope: how many, and whose. Deleting one item versus all items versus a shared team resource are different actions and read differently.
+- Consequence: reversible or permanent, and who is affected. A reversible archive and a permanent delete must not look the same.
+
+The label, the surrounding copy, and the friction together must make all three legible before the user commits.
+
+## Naming actions
+
+- Destructive and primary CTAs use Verb plus Noun naming the object: `Delete project`, `Remove member`, `Discard changes` (`rule/destructive-names-action`).
+- Never `Confirm`, `OK`, `Yes`, `Submit`, or a bare verb on a destructive action. These hide what happens (`rule/no-confirm-ok-labels`, defined in `copywriting`).
+- Use the canonical verb for the operation and keep it consistent across the product (`rule/canonical-verb`). Do not call the same operation "Delete" in one place and "Remove" in another.
+- The verb pairs with the consequence: `Delete` implies permanent, `Remove` implies detach, `Archive` implies recoverable, `Cancel` abandons an in-progress action, `Discard` drops unsaved edits.
+
+## Disambiguation pairs
+
+Common verbs that get confused. Keep them distinct (full vocabulary in `copywriting/references/ui-states.md`):
+
+| If the action | Use | Not |
+|---------------|-----|-----|
+| Permanently destroys the object | Delete | Remove |
+| Detaches without destroying | Remove | Delete |
+| Reversibly hides | Archive | Delete |
+| Abandons an in-progress flow | Cancel | Discard |
+| Drops unsaved edits | Discard | Cancel |
+| Adds an existing thing | Add | Create |
+| Makes a new thing | Create | Add |
+
+## State copy at a glance
+
+For full state-copy rules, route to `copywriting/references/ui-states.md`. The product-level expectations:
+
+- Error: what happened, why when known, the recovery action. No raw exceptions (`rule/error-states-recovery`).
+- Empty: name the object, offer the first action, no dead ends (`rule/empty-state-action`).
+- Loading: specific over "Loading..." when the target is known (`rule/loading-state-specific`).
+
+## When to route to copywriting
+
+Hand off when the work is about words rather than the action decision:
+
+- Rewriting multiple strings for tone or voice.
+- Persuasion, hero copy, CTAs on marketing surfaces.
+- Removing AI-isms or running the copy sweeps.
+- Choosing between two acceptable phrasings on style grounds.
+
+Keep here only the decision of what the action is and what it must say to be honest about object, scope, and consequence.

--- a/skills/product-design/references/product-judgment.md
+++ b/skills/product-design/references/product-judgment.md
@@ -1,0 +1,98 @@
+# Product Judgment
+
+Load in `shape` mode and for any material product or flow decision. This file is about deciding what should exist before deciding how it looks. The visual execution belongs to `ui-design`; the decision belongs here.
+
+A material decision changes the user's task, default, scope, consequence, navigation, interaction surface, or reachable states. Copy mechanics, token swaps, and established component substitutions usually are not material.
+
+## Write the brief first
+
+Before proposing any UI, write a compact internal brief. Do not skip to components.
+
+- User: who is acting, and what do they know coming in.
+- Job: what they are trying to accomplish, in their words.
+- Current behavior: what happens today, and where it fails them.
+- Desired outcome: the behavior that solves the job.
+- Success signal: how you would know it worked.
+- Non-goals: what this explicitly does not do.
+- Object: the product noun being acted on.
+- Action, scope, consequence: what changes, how much, and whether it is reversible.
+- Permissions: who can do this, and what the unprivileged path looks like.
+- Open decisions: the product questions still unresolved.
+
+If you cannot fill in job, desired outcome, and consequence, stop and ask. The interface is unbuildable until those are clear, and guessing them produces confident, wrong work.
+
+## Separate facts from decisions
+
+Mark assumptions and unresolved product choices explicitly. Do not bury a product decision inside an implementation detail where no one will review it. A reviewer should be able to see, at a glance, what is known versus what you decided.
+
+Shipped code is evidence of what exists, not proof that it is correct. Check it against current components, real product behavior, and explicit guidance before treating it as precedent. One shipped file is not a standard.
+
+## Control selection
+
+Pick the control from the shape of the choice, not from habit.
+
+| The choice is | Use | Avoid |
+|---------------|-----|-------|
+| 2 to 3 static, mutually exclusive options | Radio or segmented control (all visible) | A select that hides options (`rule/control-matches-cardinality`) |
+| Many options, or dynamic | Select or combobox | A long radio list |
+| A binary on/off applied immediately | Switch | A checkbox that needs a save |
+| A binary agreement saved with a form | Checkbox | A switch |
+| One action | Button | A menu with one item |
+| Navigation to a location | Link (`rule/navigation-vs-action`) | A button that pushes history |
+
+When two controls both fit, choose the one that keeps options visible and reversible.
+
+## Surface persistence
+
+Match the weight of the surface to the importance of the decision.
+
+- Inline disclosure first: expand in place, reveal a section, anchor a popover to its trigger. Keeps context (`rule/inline-before-modal`).
+- Modal only for a focused, interrupting decision that needs full attention. Never stack modals (`rule/no-nested-modals`).
+- New page or route when the task is large, shareable, or its own destination.
+- Expose advanced controls when needed without forcing the default path to carry their complexity. The common case stays simple; power is available, not mandatory.
+
+## Smallest coherent intervention
+
+Before adding UI, work through cheaper options in order (`rule/smallest-intervention`):
+
+1. A better default. Can the right thing happen without the user choosing?
+2. A behavior change. Can the system do this automatically and reliably?
+3. Reuse. Does an existing pattern already solve this job?
+4. New UI. Only when the above do not.
+
+Strong defaults and direct behavior beat configuration the user must learn and maintain. Do not solve one job by creating unrelated settings or abstractions. Adding a toggle is a decision deferred to the user, not a decision made.
+
+## Hierarchy and structure
+
+- One primary action per surface (`rule/one-primary-action`). Make the primary task and action unmistakable; everything else recedes.
+- Group with hierarchy, spacing, and alignment before reaching for containers (`rule/structure-before-containers`). Nested boxes add weight, not meaning.
+- Preserve the user's context and mental model unless changing it solves a verified problem (`rule/preserve-mental-model`).
+
+## Semantics
+
+Use navigation components for navigation and action components for actions (`rule/navigation-vs-action`). The semantic, not the styling, determines keyboard behavior, focus role, and assistive-technology output. A `div` with an onClick is not a button.
+
+## Evidence over taste
+
+Trace each non-mechanical decision to one of:
+
+1. The user's explicit goal and constraints.
+2. Verified product behavior and system truth (what the mutation actually does).
+3. Repository-canonical guidance: the project's `AGENTS.md`, its design system, and routed sibling skills.
+4. An accepted product or design decision with stable evidence.
+5. A verified adjacent shipped pattern in the same product area.
+6. General interface heuristics, only when nothing above applies.
+
+If a decision rests only on heuristics or preference, say so and flag it as open. Do not present taste as evidence.
+
+## The decision checklist
+
+For each non-mechanical change, be able to answer:
+
+- What user problem does this solve?
+- Why is this component or interaction appropriate?
+- What consequence must the interface communicate?
+- Which evidence supports the decision?
+- What is the smallest coherent change that achieves it?
+
+If any answer is missing, the decision is not ready to build. Resolve information architecture, component semantics, interaction, and state behavior before styling or rewriting copy.

--- a/skills/product-design/references/rules.md
+++ b/skills/product-design/references/rules.md
@@ -1,0 +1,197 @@
+# Product Design Rules
+
+Stable rule IDs cited across every mode. Each finding or decision in `product-design` names a rule ID so it is traceable, dedupable, and verifiable against a source. Treat these IDs as a shared vocabulary: lint rules, reviews, and exemplars all reference the same slug.
+
+Cite an ID exactly as written (`rule/destructive-names-action`). Never invent one. If a needed rule does not exist, record it as a coverage gap in `evals/README.md` rather than citing a made-up ID.
+
+## How to read a rule
+
+| Field | Meaning |
+|-------|---------|
+| Scope | The surface or decision the rule governs |
+| Rule | The decision, stated as an observable constraint, not an adjective |
+| Why | The user consequence when violated |
+| Source | Where the rule is enforced or detailed: a lint rule, a reference section, or a sibling skill |
+| Enforcement | `lint` (deterministic, see `lint/`), `judgment` (this skill), or `copy` (defined in `copywriting`) |
+
+A rule is observable when you can point at the interface and say it passes or fails without invoking taste. "Destructive actions use Verb plus Noun" is observable. "Buttons should be clear" is not, and does not belong here.
+
+## Interaction and control selection
+
+### rule/control-matches-cardinality
+- Scope: choosing a control for a small set of mutually exclusive options.
+- Rule: 2 to 3 static, mutually exclusive options use radio buttons or a segmented control, not a select. Keep every option visible.
+- Why: a select hides choices behind a click and a label, so the user cannot compare options at a glance.
+- Source: `lint/rules/prefer-radio-for-few-options.js`; `product-judgment.md` > Control selection.
+- Enforcement: lint plus judgment.
+
+### rule/navigation-vs-action
+- Scope: any clickable element.
+- Rule: use a link for navigation (changes location, shareable, back-button safe) and a button for an action (mutates state, submits, opens an overlay). Do not style one as the other.
+- Why: the wrong semantic breaks the back button, open-in-new-tab, keyboard activation, and screen-reader role.
+- Source: `product-judgment.md` > Semantics; `ui-audit` for the rendered check.
+- Enforcement: judgment.
+
+### rule/no-nested-modals
+- Scope: overlays.
+- Rule: do not open a modal from within a modal. Resolve the first, use a single multi-step surface, or move the second step inline.
+- Why: stacked modals break focus trapping, escape-key order, and layering, and they hide the original context.
+- Source: `lint/rules/no-nested-modals.js`; `surfaces.md` > Overlays.
+- Enforcement: lint plus judgment.
+
+### rule/inline-before-modal
+- Scope: revealing secondary content or controls.
+- Rule: prefer inline disclosure (expand in place, a section, a popover anchored to its trigger) before introducing a modal. Reserve modals for focused, interrupting decisions.
+- Why: a modal severs the user from context and forces a full-attention detour for work that often does not need one.
+- Source: `product-judgment.md` > Surface persistence.
+- Enforcement: judgment.
+
+### rule/smallest-intervention
+- Scope: any proposed change that adds UI.
+- Rule: before adding a control, setting, or surface, evaluate a better default, a behavior change, or reuse of an existing pattern. Add UI only when those do not solve the job.
+- Why: every added control is a permanent cost the user must learn and the team must maintain. Configuration is not a substitute for a correct default.
+- Source: `product-judgment.md` > Smallest coherent intervention.
+- Enforcement: judgment.
+
+## Action naming and consequence
+
+### rule/destructive-names-action
+- Scope: confirmation and primary buttons for destructive or irreversible actions.
+- Rule: destructive CTAs use Verb plus Noun naming the exact object (`Delete project`, `Remove member`, `Discard changes`). Never `Confirm`, `OK`, `Yes`, or a bare verb.
+- Why: a generic label hides what is about to happen, so the user confirms an action they did not fully read.
+- Source: defined in `copywriting/references/ui-states.md`; cited by `naming-and-copy.md`.
+- Enforcement: copy plus judgment.
+
+### rule/name-object-scope-consequence
+- Scope: any action that mutates, deletes, shares, bills, or changes permissions.
+- Rule: the interface states the object (what), the scope (how many, whose), and the consequence (reversible or not, who is affected) before the user commits.
+- Why: without scope and consequence the user cannot judge the blast radius of the action.
+- Source: `naming-and-copy.md` > Object, scope, consequence; `product-judgment.md`.
+- Enforcement: judgment.
+
+### rule/destructive-proportional
+- Scope: destructive actions.
+- Rule: make friction proportional to impact. Offer undo when the system can honestly support it. Require typed confirmation only for high-impact, irreversible actions, not routine ones.
+- Why: under-protecting a permanent delete causes data loss; over-protecting a reversible one trains users to click through warnings.
+- Source: `surfaces.md` > Destructive state; `interface-quality.md` > Resilience.
+- Enforcement: judgment.
+
+### rule/preserve-user-input
+- Scope: forms, editors, and any input across validation, error, or navigation.
+- Rule: preserve user input through validation failures and recoverable errors. Do not clear fields on a failed submit.
+- Why: discarding entered data on error forces re-entry and is the fastest way to lose a user's work and trust.
+- Source: `surfaces.md` > Error state; `ux-audit` for the React-level check.
+- Enforcement: judgment.
+
+## State coverage
+
+### rule/cover-reachable-states
+- Scope: any surface that loads, mutates, or depends on data or permissions.
+- Rule: design every state the surface can actually enter: loading, empty, sparse, populated, error, permission-denied, partial or stale, optimistic, and destructive-in-progress. A happy-path-only design is incomplete.
+- Why: unhandled states ship as blank screens, spinners that never resolve, or actions that silently fail.
+- Source: `surfaces.md` (the full enumeration).
+- Enforcement: judgment.
+
+### rule/empty-state-action
+- Scope: empty and zero-data states.
+- Rule: an empty state names the object and offers the first action. No dead ends.
+- Why: a bare "No items" leaves the user with nothing to do and no idea how to begin.
+- Source: defined in `copywriting/references/ui-states.md`; `surfaces.md` > Empty state.
+- Enforcement: copy plus judgment.
+
+### rule/error-states-recovery
+- Scope: error states and failure messages.
+- Rule: an error states what happened, why when known, and the recovery action. Never surface raw exception or stack text. Never a bare "Something went wrong" with no next step.
+- Why: an error without a recovery path strands the user.
+- Source: defined in `copywriting/references/ui-states.md`; `surfaces.md` > Error state.
+- Enforcement: copy plus judgment.
+
+### rule/loading-stable-labels
+- Scope: controls in a loading or busy state.
+- Rule: keep the control's label stable while busy and use the component's loading or busy affordance. Do not swap the label for "Loading..." or change its width.
+- Why: a shifting label causes layout jump and hides which action is in flight.
+- Source: `surfaces.md` > Loading state; `loading-state-specific` in `copywriting`.
+- Enforcement: judgment.
+
+### rule/loading-state-specific
+- Scope: loading copy.
+- Rule: prefer specific loading text over a bare "Loading..." when the target is known (what is loading, and roughly how long for long operations).
+- Why: specific feedback tells the user the system is working on their request, not stuck.
+- Source: defined in `copywriting/references/ui-states.md`.
+- Enforcement: copy.
+
+## Accessibility as a product concern
+
+### rule/accessible-name-required
+- Scope: icon-only buttons, icon links, and form controls.
+- Rule: every interactive control has an accessible name (visible label, `aria-label`, or associated `<label>`). Icon-only controls are never nameless.
+- Why: a nameless control is unusable by screen readers and ambiguous for everyone under load.
+- Source: `lint/rules/icon-button-accessible-name.js`; `interface-quality.md` > Accessibility.
+- Enforcement: lint plus judgment.
+
+### rule/keyboard-complete-flow
+- Scope: any multi-step or interactive flow.
+- Rule: the primary task is completable by keyboard alone, with visible focus and a sensible focus order. Focus moves to new surfaces and returns on close.
+- Why: keyboard and screen-reader users must be able to finish the job, not just reach the first control.
+- Source: `interface-quality.md` > Accessibility; route rendered checks to `ui-audit`.
+- Enforcement: judgment.
+
+### rule/no-custom-focus-bypass
+- Scope: focus styling.
+- Rule: do not remove or replace the shared focus ring with a custom outline that bypasses the design system's focus token. Keep focus visible and consistent.
+- Why: invisible or inconsistent focus makes keyboard navigation impossible to follow.
+- Source: `lint/rules/no-design-system-override.js`; `interface-quality.md`.
+- Enforcement: lint plus judgment.
+
+## Visual system integrity
+
+### rule/no-design-system-override
+- Scope: components from the project's design system.
+- Rule: do not use `className` (or `style`) to override a design-system component's color, radius, shadow, or focus treatment. Layout utilities (margin, width, grid placement) are allowed.
+- Why: per-instance overrides fork the system, break theming and dark mode, and drift over time.
+- Source: `lint/rules/no-design-system-override.js`; route visual rebuilds to `ui-design`.
+- Enforcement: lint plus judgment.
+
+### rule/material-over-raw-shadow
+- Scope: elevation and surfaces.
+- Rule: use the design system's theme-aware surface or material classes instead of raw shadow utilities, and do not add a border that duplicates a material's built-in treatment.
+- Why: raw shadows ignore the theme and break in dark mode; duplicate borders double the visual weight.
+- Source: `lint/rules/no-raw-shadow.js`; route to `ui-design` for the visual decision.
+- Enforcement: lint.
+
+### rule/spacing-on-grid
+- Scope: spacing utilities.
+- Rule: spacing follows the project's grid (commonly a 4px base). Flag arbitrary off-grid values and prefer a standard utility when one exists.
+- Why: off-grid spacing reads as visual noise and accumulates into inconsistent rhythm.
+- Source: `lint/rules/off-grid-spacing.js`; route taste calls to `ui-design`.
+- Enforcement: lint.
+
+### rule/modal-body-scroll
+- Scope: modal and dialog composition.
+- Rule: long modal content lives in the design system's scroll container (for example a `Modal.Body`) so the body scrolls while header and footer stay fixed.
+- Why: without it, long content pushes the actions off-screen and the user cannot reach the confirm or cancel button.
+- Source: `lint/rules/require-modal-body.js`; `surfaces.md` > Overlays.
+- Enforcement: lint.
+
+## Hierarchy and structure
+
+### rule/one-primary-action
+- Scope: any surface or section.
+- Rule: the primary task and its primary action are unmistakable. At most one primary (emphasized) action per surface; everything else is secondary or tertiary.
+- Why: competing primary actions split attention and slow every decision.
+- Source: `product-judgment.md` > Hierarchy.
+- Enforcement: judgment.
+
+### rule/structure-before-containers
+- Scope: layout.
+- Rule: use hierarchy, spacing, and alignment to group content before adding borders, cards, or boxes.
+- Why: container-first layouts produce nested boxes that add visual weight without adding meaning.
+- Source: `product-judgment.md` > Hierarchy; route visual execution to `ui-design`.
+- Enforcement: judgment.
+
+### rule/preserve-mental-model
+- Scope: navigation and context changes.
+- Rule: preserve the user's current context and mental model unless changing it solves a verified problem. Do not relocate the user or reset their state as a side effect.
+- Why: unexpected context shifts disorient the user and lose their place.
+- Source: `product-judgment.md` > Context.
+- Enforcement: judgment.

--- a/skills/product-design/references/surfaces.md
+++ b/skills/product-design/references/surfaces.md
@@ -1,0 +1,94 @@
+# Surfaces and Reachable States
+
+Load in `shape`, `implement`, and `harden` modes. This is the most concrete value the skill carries: a happy-path mockup is incomplete, not done. Design every state the surface can actually enter, and only those.
+
+Govern coverage with `rule/cover-reachable-states`. Map only reachable states: do not invent a permission-denied state for a surface everyone can reach, but do not stop at the populated success case either.
+
+## Map the surface before the states
+
+Inventory the surface first:
+
+- Entry points: how the user arrives, and from where.
+- Visible regions: header, body, actions, secondary panels.
+- Overlays: modals, popovers, sheets, toasts.
+- Transitions: what changes on action, and what animates.
+- Exits and return paths: where the user goes on success, cancel, or error, and how they get back.
+
+Then walk the state list below and mark each as reachable or not for this surface.
+
+## The reachable-state checklist
+
+```
+State coverage:
+- [ ] Loading (initial, and per-action busy)
+- [ ] Empty (no data yet)
+- [ ] Sparse (one or a few items; layout still holds)
+- [ ] Populated (the success case)
+- [ ] Partial / stale (some data, some pending or outdated)
+- [ ] Validation (inline, before submit)
+- [ ] Error (the action or load failed)
+- [ ] Permission-denied (the user cannot do this)
+- [ ] Disabled (the action is unavailable right now, and why)
+- [ ] Optimistic (shown applied before the server confirms)
+- [ ] Destructive-in-progress (confirm, pending, undo window)
+- [ ] Responsive (compact and wide; long content; large values)
+```
+
+## Loading state
+
+- Keep the triggering control's label stable; use its busy affordance, do not swap the text (`rule/loading-stable-labels`).
+- Distinguish initial load (skeleton or placeholder for the region) from per-action busy (the specific control).
+- For known targets, prefer specific loading copy over a bare "Loading..." (`rule/loading-state-specific`).
+- A spinner that can hang forever needs a timeout path that lands in the error state.
+
+## Empty state
+
+- Name the object and offer the first action (`rule/empty-state-action`). "No projects yet" plus a "Create project" action, not a bare "No data".
+- Distinguish never-had-any (onboarding tone, guide the first step) from filtered-to-zero (offer to clear the filter).
+- An empty state is a first impression, not an error. No dead ends.
+
+## Sparse and populated
+
+- The layout must hold with one item, not just twenty. A grid of one should not look broken.
+- The populated case is the baseline, not the finish line. If it is the only state you designed, the work is a `rule/cover-reachable-states` failure.
+
+## Partial and stale
+
+- When some data is pending or outdated, show what is known and mark what is not. Do not block the whole surface on the slowest part.
+- For stale data, indicate it is stale and offer a refresh rather than silently showing old values as current.
+
+## Validation and error
+
+- Validate inline where possible, before submit, so the user fixes problems in context.
+- On failure, preserve every field the user entered (`rule/preserve-user-input`). Never clear the form.
+- Error copy states what happened, why when known, and the recovery action; never raw exception text (`rule/error-states-recovery`).
+- Separate field-level errors (fix this input) from surface-level errors (the whole action failed).
+
+## Permission and disabled
+
+- A permission-denied path is a designed state, not a crash. Explain what the user lacks and, when relevant, how to request it.
+- A disabled control says why it is disabled (tooltip, helper text, or adjacent message). A silently disabled button is a dead end.
+- Do not show actions the user can never take; do show actions they could take with different permissions, clearly gated.
+
+## Optimistic updates
+
+- When you show a change before the server confirms, design the rollback: what the user sees if it fails, and how their input is preserved.
+- Optimistic UI without a failure path is a happy-path shortcut, not a complete state.
+
+## Destructive state
+
+- Name the object and consequence before the user commits (`rule/name-object-scope-consequence`, `rule/destructive-names-action`).
+- Make friction proportional to impact and offer undo when honestly supported (`rule/destructive-proportional`).
+- Design the in-progress and post-action states: pending, success with undo window, and failure.
+
+## Overlays
+
+- Never nest modals (`rule/no-nested-modals`). Resolve, sequence, or inline the second step.
+- Long modal content scrolls inside the body container so actions stay reachable (`rule/modal-body-scroll`).
+- Focus moves into the overlay on open and returns to the trigger on close; escape closes it.
+
+## Responsive and resilience handoff
+
+- Check compact and wide viewports for every materially changed state.
+- Test long strings, large numbers, constrained width, and localization or RTL risk.
+- Overflow, localization, extreme data, and network resilience details live in `interface-quality.md` > Resilience.


### PR DESCRIPTION
## Summary

Adapts the Vercel "Teaching agents product design" system into this repo: a new `product-design` skill, a real runnable lint package, and a review-loop/eval bundle, plus product-state copy rules folded into `copywriting`. All content is generalized (no Vercel/Geist specifics) and routes to the project's own design system and sibling skills.

## Skills added

- **product-design** (new, under Design): owns product and UX judgment and correctness, distinct from `ui-design` (visual build). It decides what should exist, then routes implementation out.
  - Routes by request mode: `shape`, `implement`, `review`, `copy`, `harden`.
  - IS/IS-NOT boundary and an ordered Decision Authority hand off visual build to `ui-design`, rendered/a11y audits to `ui-audit`, React/Next diff bug-hunts to `ux-audit`, and wording to `copywriting`.
  - References: `product-judgment.md`, `surfaces.md` (reachable-state coverage), `interface-quality.md` (standards + P0-P3 rubric + resilience), `naming-and-copy.md`, and `rules.md` (26 stable `rule/<slug>` IDs, the citation spine).

## Skills changed

- **copywriting**: new `references/ui-states.md` (destructive CTAs use Verb + Noun, canonical product verbs, error/empty/loading copy) defining six shared rule IDs that `product-design` cites. Added a `[STATE-COPY]` edit-mode label, a reference-table row, a handoff to `product-design`, and state-copy triggers in the description (kept under 1024 chars).

## Tooling

- **Runnable ESLint plugin** at `skills/product-design/references/lint/` (`eslint-plugin-product-design`): seven JSX-semantic rules (prefer-radio, no-nested-modals, icon-button-accessible-name, no-design-system-override, require-modal-body, no-raw-shadow, off-grid-spacing), each configurable to a project's own design system. A flat-config preset, an example config, and a RuleTester suite (`npm test` passes all 7). Formatting is left to oxfmt/oxlint or Biome; ESLint owns the custom semantic rules since that is the only mature path for them.
- **Evals + review loop** at `references/evals/`: judge rubric, three generic before/after fixtures, and the collector → judge → human-packet weekly intake process, documented as recommended practice.

## README

- Skill count 25 → 26, new `product-design` bullet under Design, and a state-copy note on the `copywriting` bullet.

## Verification

- `npm install && npm test` in the lint package: 7/7 rules pass.
- No em dashes in any authored file (the source blog uses them).
- `SKILL.md` is 138 lines (cap 500); both edited descriptions are under 1024 chars.
- All 26 cited rule IDs are defined; no dangling citations.
- Every `SKILL.md` reference link resolves; `ls skills/ | wc -l` equals the README count (26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xkih5joejpciDWzmzpikQP)_