### PR TITLE
Add agent-friendly codebase reference to define-architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Code review catches logic bugs. Nobody checks the loading states, the type scale
 
 ### Architecture
 
-- **[define-architecture](./skills/define-architecture/SKILL.md)**: Folder structures, module contracts, and middleware pipelines for TypeScript apps, plus deepening existing codebases.
+- **[define-architecture](./skills/define-architecture/SKILL.md)**: Folder structures, module contracts, and middleware pipelines for TypeScript apps, plus deepening existing codebases and agent-friendly codebase guardrails.
 - **[scaffold-nextjs](./skills/scaffold-nextjs/SKILL.md)**: Scaffolds a Next.js turborepo with Blode UI, Ultracite tooling, GitHub setup, and Vercel deploy.
 - **[scaffold-cli](./skills/scaffold-cli/SKILL.md)**: Scaffolds a TypeScript CLI/npm package: ESM, dual tsdown build, vitest, ultracite, changesets, GitHub Actions.
 - **[multi-tenant-architecture](./skills/multi-tenant-architecture/SKILL.md)**: Multi-tenant domain strategy, isolation, routing, custom domains, and plan mapping on Cloudflare or Vercel.

--- a/skills/define-architecture/SKILL.md
+++ b/skills/define-architecture/SKILL.md
@@ -42,7 +42,7 @@ Load references only when the condition applies:
 | [references/distributed-correctness.md](references/distributed-correctness.md) | Designing flows that call external systems, consume webhooks, retry, or need an audit trail |
 | [references/deepening-existing.md](references/deepening-existing.md) | Running the Adoption workflow (domain mapping, opportunity patterns, output template) |
 | [references/craftsmanship.md](references/craftsmanship.md) | Writing the team-conventions or testing sections |
-| [references/agent-friendly-codebase.md](references/agent-friendly-codebase.md) | Preparing a codebase for coding agents: guardrail tooling, legacy markers, traversal-friendly naming |
+| [references/agent-friendly-codebase.md](references/agent-friendly-codebase.md) | Preparing a codebase for coding agents: guardrail tooling, invariant ratchets, legacy markers, generated contracts, verification tiers |
 | [references/shipping-practices.md](references/shipping-practices.md) | Writing the rollout and rollback section |
 
 ## Setup workflow (new codebase)

--- a/skills/define-architecture/SKILL.md
+++ b/skills/define-architecture/SKILL.md
@@ -7,7 +7,7 @@ description: Generates folder structures, module contracts, middleware pipelines
 
 Define durable, easy-to-change architecture defaults for TypeScript full-stack apps; produce an enforceable architecture brief.
 
-- **IS:** folder structures, module contracts, middleware pipelines, frontend/backend boundaries; architecture briefs; domain-informed deepening of an existing codebase.
+- **IS:** folder structures, module contracts, middleware pipelines, frontend/backend boundaries; architecture briefs; domain-informed deepening of an existing codebase; agent-friendly codebase guardrails.
 - **IS NOT:** scaffolding a new repo (`scaffold-nextjs` for a Next.js turborepo, `scaffold-cli` for a TypeScript CLI), multi-tenant domain/isolation/routing (`multi-tenant-architecture`), or structural review of a local diff (`pr-reviewer`).
 
 ## Contents

--- a/skills/define-architecture/SKILL.md
+++ b/skills/define-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: define-architecture
-description: Generates folder structures, module contracts, middleware pipelines, and frontend/backend boundaries for TypeScript full-stack applications, and finds domain-informed deepening opportunities in existing codebases. Use when setting up project structure, organizing a monorepo, defining folder layout, designing backend modules, establishing team conventions, improving architecture outside a local diff, writing an architecture brief, or asking "how should I structure this app", "design the folder structure", "set up the architecture", or "find architecture improvements". For scaffolding a new Next.js repo use scaffold-nextjs, for a new TypeScript CLI use scaffold-cli, for multi-tenant domain or isolation strategy use multi-tenant-architecture, and for structural review of a local diff use pr-reviewer.
+description: Generates folder structures, module contracts, middleware pipelines, and frontend/backend boundaries for TypeScript full-stack applications, and finds domain-informed deepening opportunities in existing codebases. Use when setting up project structure, organizing a monorepo, defining folder layout, designing backend modules, establishing team conventions, improving architecture outside a local diff, writing an architecture brief, or asking "how should I structure this app", "design the folder structure", "set up the architecture", "find architecture improvements", "make this codebase agent-friendly", or "set up guardrails for coding agents". For scaffolding a new Next.js repo use scaffold-nextjs, for a new TypeScript CLI use scaffold-cli, for multi-tenant domain or isolation strategy use multi-tenant-architecture, and for structural review of a local diff use pr-reviewer.
 ---
 
 # Define Architecture
@@ -42,6 +42,7 @@ Load references only when the condition applies:
 | [references/distributed-correctness.md](references/distributed-correctness.md) | Designing flows that call external systems, consume webhooks, retry, or need an audit trail |
 | [references/deepening-existing.md](references/deepening-existing.md) | Running the Adoption workflow (domain mapping, opportunity patterns, output template) |
 | [references/craftsmanship.md](references/craftsmanship.md) | Writing the team-conventions or testing sections |
+| [references/agent-friendly-codebase.md](references/agent-friendly-codebase.md) | Preparing a codebase for coding agents: guardrail tooling, legacy markers, traversal-friendly naming |
 | [references/shipping-practices.md](references/shipping-practices.md) | Writing the rollout and rollback section |
 
 ## Setup workflow (new codebase)
@@ -75,6 +76,7 @@ Load references only when the condition applies:
 6. Testing and release:
    - Unit tests stay DB-free; integration/E2E run in parallel with dynamically generated IDs so runs never collide on fixtures.
    - Release in small, reversible steps with a rollback plan per change.
+7. Agent guardrails: wire dead-code, duplication, boundary, and file-size checks into pre-commit and CI per [references/agent-friendly-codebase.md](references/agent-friendly-codebase.md); anything a static tool can enforce stays out of AGENTS.md.
 
 ## Adoption workflow (existing codebase)
 
@@ -84,7 +86,7 @@ Goal: domain-informed deepening, not a rewrite. Load [references/deepening-exist
 2. **Find deepening opportunities.** Look for anemic concepts, leaking boundaries, naming divergence, duplicated concepts, primitive obsession, misplaced logic. Record each with file paths, never a vague smell.
 3. **Rank by leverage.** Prefer opportunities that localize named future changes, have low churn, and meet a current requirement. Drop speculative cleanups.
 4. **Migrate one vertical slice first.** Prove the highest-leverage move end to end through one slice before generalizing.
-5. **Add guardrails.** Enforce the new boundary with lint, type, or test checks so it cannot decay, then roll out module by module.
+5. **Add guardrails.** Enforce the new boundary with lint, type, or test checks so it cannot decay, then roll out module by module. For agent-specific guardrails (dead code, duplication, legacy markers, file-size caps) load [references/agent-friendly-codebase.md](references/agent-friendly-codebase.md).
 
 ## Validation loop
 
@@ -120,6 +122,8 @@ Use this structure:
 - `multi-tenant-architecture`: tenant identification, isolation, and domain strategy.
 - `pr-reviewer`: structural review of a local diff once implemented.
 - `planning`: turn an Adoption opportunity into an implementation plan, then stress-test it.
+- `agents-md`: audit and refactor the AGENTS.md file itself; this skill decides what belongs in tooling instead.
+- `tidy`: diff-scoped cleanup pass; `references/agent-friendly-codebase.md` covers the repo-wide guardrail setup that keeps those passes small.
 
 ## Gotchas
 
@@ -133,3 +137,5 @@ Use this structure:
 - Don't finalize a brief without a rollback plan per change: an irreversible decision needs a documented fallback before it ships.
 - Don't dual-write to a database and a queue/webhook without an outbox (or CDC): one side commits, the other fails, and you silently lose or fabricate a notification. See `references/distributed-correctness.md`.
 - Don't enforce an externally-forceable invariant by construction (unsigned type, hard CHECK): when the outside world forces the state, the system crashes or clamps instead of recording it. Represent it, detect it post-factum, recover explicitly.
+- Don't encode in AGENTS.md what a linter can enforce deterministically: a prompt rule decays under context pressure; an exit code in pre-commit and CI does not.
+- Don't leave legacy code unmarked next to current patterns: agents grep, find the old endpoint first, and build on it. Mark it with a greppable LEGACY comment or delete it (see `references/agent-friendly-codebase.md`).

--- a/skills/define-architecture/references/agent-friendly-codebase.md
+++ b/skills/define-architecture/references/agent-friendly-codebase.md
@@ -2,6 +2,21 @@
 
 Make a codebase cheap and safe for coding agents to work in. Load when preparing a repo for agentic coding, wiring guardrail tooling, or marking legacy code.
 
+## Contents
+
+1. [Why agents care](#why-agents-care)
+2. [Deterministic guardrails over prompt rules](#deterministic-guardrails-over-prompt-rules)
+3. [Bespoke invariant guards with a ratchet](#bespoke-invariant-guards-with-a-ratchet)
+4. [Legacy quarantine](#legacy-quarantine)
+5. [Generated contracts](#generated-contracts)
+6. [Locality and naming for cheap traversal](#locality-and-naming-for-cheap-traversal)
+7. [Verification tiers](#verification-tiers)
+8. [Errors agents can debug](#errors-agents-can-debug)
+9. [Docs agents can trust](#docs-agents-can-trust)
+10. [Self-bootstrapping worktrees](#self-bootstrapping-worktrees)
+11. [Scheduled refactor passes](#scheduled-refactor-passes)
+12. [Convention entries](#convention-entries)
+
 ## Why agents care
 
 Code cleanliness does not change an agent's pass rate; it changes the cost of every task. On matched clean/messy repos, Claude Code used 7 to 8% fewer tokens and revisited files 34% less often when the code was clean (SonarSource, 2026). Two mechanisms drive this:

--- a/skills/define-architecture/references/agent-friendly-codebase.md
+++ b/skills/define-architecture/references/agent-friendly-codebase.md
@@ -22,6 +22,19 @@ TypeScript-first tools per category (swap per ecosystem; the categories are lang
 | Import boundaries and cycles | `dependency-cruiser` or eslint `boundaries` | Layer violations (enforce the handler/service/dao contract) |
 | File size and complexity | eslint `max-lines` (~400), `complexity` | Files too big to read in one pass |
 
+## Bespoke invariant guards with a ratchet
+
+Generic linters stop at generic rules. The invariants that define your architecture (layer contracts like "DAOs never import handlers", naming rules like "derive identity from file path", bans like "no `as unknown as` double-casts") go in a custom guard script that fails the build on violation. Three properties make the guard agent-grade:
+
+- **Self-explaining failures.** Every violation prints why the invariant exists and how to fix it, not just where it fired. The agent self-corrects on the spot instead of guessing or asking a reviewer.
+- **A shrink-only baseline.** Pre-existing violations live in a committed baseline file (JSON list of file paths or counts). The guard passes while violations stay at or below the baseline and fails when they grow, so a new rule enforces repo-wide on day one while migration happens incrementally. Fix violations; never edit the baseline upward.
+- **Graduated enforcement.** A warn-only variant runs in pre-commit for fast signal without blocking work-in-progress commits; the blocking variant runs in CI and gates the merge.
+
+Two guard shapes worth copying:
+
+- **Registry completeness as a reflection test.** When every X must be registered (tools in a manifest, tables in a deletion sweep, routes with an auth policy), write a test that reflects over the real code and fails when an item is missing from the registry or the allowlist. Nothing can be added without declaring it.
+- **Deprecation greps.** Removed APIs, commands, and packages must not reappear in active code or docs; each hit prints the sanctioned replacement. Exclude changelogs, they are historical record. Boundary-lint messages should also name the rule and link the architecture doc, so the failure teaches the convention it enforces.
+
 ## Legacy quarantine
 
 Mixed-quality code teaches agents the wrong conventions, and deleting legacy is not always an option. Quarantine what stays:
@@ -30,6 +43,17 @@ Mixed-quality code teaches agents the wrong conventions, and deleting legacy is 
 - Keep `docs/legacy.md` short: which areas are frozen, why, and what to use instead. Comments reference it instead of repeating it.
 - State the marker convention once in AGENTS.md so agents know what the marker means before they hit one.
 - Never leave an unmarked old/new dual path (deprecated endpoint next to its replacement, two ways to fetch the same data). Delete the old path or mark it; an unmarked pair reads as two valid conventions.
+- The invariant guard's baseline doubles as machine-readable quarantine: each entry names the module still on the old pattern and a comment names the migration it owes. The guard holds new code to the standard while the list shrinks.
+- Quarantine whole directories where that is the natural seam: a `test-legacy/` folder marked "archived, do not add to, not a source of truth" keeps an old suite runnable without teaching agents its patterns.
+
+## Generated contracts
+
+Anything derivable from a schema (API clients, GraphQL types, protobuf messages, DB models) is generated, never hand-written, so agents cannot drift a copy:
+
+- Make the schema the single source of truth and state the rule in AGENTS.md: import generated types; never hand-write an API shape the codegen already owns.
+- Commit the generated output. Agents then read real types on any checkout without knowing how to run codegen.
+- Banner every generated file with a greppable marker: `// GENERATED FILE, DO NOT EDIT. Run <command> to regenerate.` It is the same contagion defense as the LEGACY marker, pointed at the opposite failure.
+- Gate contract changes in CI: a regen-diff check (generated output matches the schema) and a breaking-change check against the published schema.
 
 ## Locality and naming for cheap traversal
 
@@ -37,6 +61,46 @@ Mixed-quality code teaches agents the wrong conventions, and deleting legacy is 
 - Keep files small enough to read in one pass; the ~400-line lint cap doubles as a traversal budget.
 - Co-locate code that changes together; a feature spread across six directories is six reads before the first edit.
 - One canonical name per concept. Naming divergence (one concept, three names) is the strongest confusion signal for agents and humans alike; see the domain-language mapping in [deepening-existing.md](deepening-existing.md).
+
+## Verification tiers
+
+An agent that knows exactly which check to run wastes no tokens running the wrong one. Name the tiers and publish the routing:
+
+- Umbrella commands per confidence level: `check` (lint + typecheck), `verify` (check + unit tests), `verify:full` (verify + integration and boot checks). AGENTS.md states which tier gates a commit.
+- Test filename conventions with latency budgets (`*.test.ts` under 3s, `*.integration.test.ts` under 10s, `*.e2e.test.ts`) so "run the narrowest relevant tier" is executable, not judgment.
+- Add a boot check that constructs the app's wiring (DI container, module graph, route registration) without serving traffic. It catches the wiring errors typecheck and unit tests both miss, which is exactly the class of error agents introduce when they add a dependency.
+- Keep `.env.example` as the canonical environment contract: the boot check loads it, and every new variable lands there or CI fails.
+- Publish file-scoped variants (typecheck, lint, test one file). The agent knows exactly which files it touched; per-file checks are the fastest loop it can run.
+- Make tests deterministic and parallel-safe: unique IDs per test (never shared fixtures), seeded randomness, a frozen clock helper. A pluggable interface can ship its behavioral spec as an importable contract test suite, so a new adapter (often agent-written) proves conformance by calling one function.
+
+## Errors agents can debug
+
+An agent debugs from the output it can read; a structured failure is the difference between one fix loop and five:
+
+- Structured error classes with a machine-readable code. Callers and tests assert on class and code, never message text; message strings are not API.
+- Two audiences by construction: a caller-safe message plus a developer-only guidance field, and user-facing copy registered separately from internal error identity so internals never leak to users.
+- Domain errors stay transport-agnostic; middleware owns the mapping to HTTP or RPC codes, so services never pick status codes ad hoc.
+- Log the raw error object and let serializers extract type, stack, and cause. Never catch-log-rethrow: middleware already logs unhandled errors once, and duplicates make the agent chase two failures.
+- Ambient request context (the RequestContext pattern in the main workflow) auto-enriches every log line with request and correlation IDs, so a failure is traceable from log output alone with no per-call-site work.
+
+## Docs agents can trust
+
+Stale docs are worse than no docs: an agent cites them confidently. Make trust explicit:
+
+- Index every agent-facing doc in AGENTS.md with a one-line "consult when" scope, so the agent knows whether to open it before paying to read it.
+- Label each doc's trust level in a docs index: live (maintained), reference (stable background), historical (point-in-time artifact, do not treat as current).
+- Validate docs in CI where possible: code snippets compile, frontmatter is well-formed, any registry that mirrors docs into code stays in sync.
+- For a pattern agents must reproduce, ship a copy-paste template file next to the prose; a working file teaches more reliably than a description of one.
+- Anchor docs to domain concepts over file paths where possible; paths go stale silently, and an agent follows a stale pointer with full confidence. Link-check doc pointers in CI, including the ones inside AGENTS.md itself.
+- Keep AGENTS.md hand-curated and update it in the same PR that changes a convention. Generating it wholesale measurably hurts: one 2026 study found LLM-generated context files reduced task success and raised inference cost.
+
+## Self-bootstrapping worktrees
+
+Agents increasingly run in fresh clones and parallel worktrees; every manual setup step is a failed session or a wasted detour:
+
+- A session-start hook that installs dependencies when they are missing makes any fresh worktree productive without instructions.
+- A post-edit hook that runs the formatter/autofixer after every file write keeps the tree always-clean instead of relying on the agent to remember.
+- For parallel agent fleets, a worktree bootstrap script copies env files, reuses dependency and codegen artifacts from the main checkout when lockfiles match, and offsets ports so worktrees never collide.
 
 ## Scheduled refactor passes
 
@@ -56,3 +120,5 @@ Ready to drop into an architecture brief (format per [craftsmanship.md](craftsma
 - **Legacy marker:** Boundary: paths listed in `docs/legacy.md`. Failure mode: agents copy deprecated patterns into new code. Enforcement: CI grep asserting every file under a listed path carries the LEGACY marker. Owner: the team that owns the migration.
 - **File size:** Boundary: all source files. Failure mode: agents burn tokens on chunked reads and revisit the file per task. Enforcement: eslint `max-lines` at ~400 with per-file overrides requiring a comment. Owner: each package.
 - **Duplication:** Boundary: all packages. Failure mode: fixes land in one copy and drift from the others. Enforcement: `jscpd` threshold in CI. Owner: platform/tooling.
+- **Invariant ratchet:** Boundary: the guard script's baseline file. Failure mode: new code copies quarantined violations and the debt grows instead of shrinking. Enforcement: guard fails CI when violations exceed the baseline; baseline edits only shrink it. Owner: platform/tooling.
+- **Generated contracts:** Boundary: schema files and committed `gen/` output. Failure mode: agents hand-edit generated files or hand-write API types that drift from the schema. Enforcement: generated-file banner plus a CI regen-diff and breaking-change check. Owner: the schema-owning package.

--- a/skills/define-architecture/references/agent-friendly-codebase.md
+++ b/skills/define-architecture/references/agent-friendly-codebase.md
@@ -108,6 +108,8 @@ Stale docs are worse than no docs: an agent cites them confidently. Make trust e
 - For a pattern agents must reproduce, ship a copy-paste template file next to the prose; a working file teaches more reliably than a description of one.
 - Anchor docs to domain concepts over file paths where possible; paths go stale silently, and an agent follows a stale pointer with full confidence. Link-check doc pointers in CI, including the ones inside AGENTS.md itself.
 - Keep AGENTS.md hand-curated and update it in the same PR that changes a convention. Generating it wholesale measurably hurts: one 2026 study found LLM-generated context files reduced task success and raised inference cost.
+- Test doc examples against the real interface. A drift test that extracts every command invocation from the published docs and skill files, resolves each against the live command tree (command path plus flags exist), and fails the build on a mismatch turns "examples must stay runnable" into a gate. Reject any past-dated example in the same test, so a stale snippet fails instead of misleading an agent.
+- Pair each non-obvious claim with the command that re-proves it. A gotcha note that ships the exact repro (`curl ...`, a one-line query) lets an agent re-verify the claim still holds instead of trusting a note that may have rotted.
 
 ## Self-bootstrapping worktrees
 

--- a/skills/define-architecture/references/agent-friendly-codebase.md
+++ b/skills/define-architecture/references/agent-friendly-codebase.md
@@ -1,0 +1,58 @@
+# Agent-friendly codebase
+
+Make a codebase cheap and safe for coding agents to work in. Load when preparing a repo for agentic coding, wiring guardrail tooling, or marking legacy code.
+
+## Why agents care
+
+Code cleanliness does not change an agent's pass rate; it changes the cost of every task. On matched clean/messy repos, Claude Code used 7 to 8% fewer tokens and revisited files 34% less often when the code was clean (SonarSource, 2026). Two mechanisms drive this:
+
+- **Traversal cost.** Agents rebuild context per task by grepping and reading. Predictable names and small files mean the first guess lands; bloated files mean chunked reads and repeated visits.
+- **Convention contagion.** Agents mimic whatever code they read first. A legacy pattern sitting unmarked next to the current one gets copied, even when AGENTS.md says otherwise.
+
+## Deterministic guardrails over prompt rules
+
+A rule an agent must remember is a suggestion; an exit code is a contract. Anything a static tool can check moves out of AGENTS.md and into tooling, wired into both a pre-commit hook (lefthook or husky) and CI. Both, always: hooks are not guaranteed installed, and CI alone gives feedback too late for the agent's edit loop. When a hook fails the agent's commit, it self-corrects on the spot; that loop is the cheapest QA round available.
+
+TypeScript-first tools per category (swap per ecosystem; the categories are language-agnostic):
+
+| Category | Tool | Catches |
+|---|---|---|
+| Dead code, unused exports and deps | `knip` | Orphaned helpers agents leave behind |
+| Copy-paste duplication | `jscpd` | Near-duplicate blocks that should share one implementation |
+| Import boundaries and cycles | `dependency-cruiser` or eslint `boundaries` | Layer violations (enforce the handler/service/dao contract) |
+| File size and complexity | eslint `max-lines` (~400), `complexity` | Files too big to read in one pass |
+
+## Legacy quarantine
+
+Mixed-quality code teaches agents the wrong conventions, and deleting legacy is not always an option. Quarantine what stays:
+
+- Mark do-not-reference code with a greppable comment at the top of each file: `// LEGACY: do not use as a reference or extend. See docs/legacy.md`.
+- Keep `docs/legacy.md` short: which areas are frozen, why, and what to use instead. Comments reference it instead of repeating it.
+- State the marker convention once in AGENTS.md so agents know what the marker means before they hit one.
+- Never leave an unmarked old/new dual path (deprecated endpoint next to its replacement, two ways to fetch the same data). Delete the old path or mark it; an unmarked pair reads as two valid conventions.
+
+## Locality and naming for cheap traversal
+
+- Name files for what an agent (or new teammate) would grep first: `invoice-refunds.ts`, not `utils2.ts` or `helpers.ts`.
+- Keep files small enough to read in one pass; the ~400-line lint cap doubles as a traversal budget.
+- Co-locate code that changes together; a feature spread across six directories is six reads before the first edit.
+- One canonical name per concept. Naming divergence (one concept, three names) is the strongest confusion signal for agents and humans alike; see the domain-language mapping in [deepening-existing.md](deepening-existing.md).
+
+## Scheduled refactor passes
+
+Agent-written code accretes single-use helpers, stale dual paths, and bloated files even with guardrails. Schedule small cleanup passes instead of waiting for a rewrite:
+
+1. Run the dead-code and duplication tools; delete what they flag.
+2. Split any file over the size cap along its natural seams.
+3. One slice at a time, verified by the existing test suite; never big-bang (the Adoption workflow's slice rule applies).
+
+Refactor safety equals test coverage: a thin suite caps how aggressive a pass can be, so growing coverage is part of staying agent-friendly, not a separate track.
+
+## Convention entries
+
+Ready to drop into an architecture brief (format per [craftsmanship.md](craftsmanship.md)):
+
+- **Dead code:** Boundary: all packages. Failure mode: agents grep dead helpers, treat them as live conventions, and extend them. Enforcement: `knip` in pre-commit and CI. Owner: platform/tooling.
+- **Legacy marker:** Boundary: paths listed in `docs/legacy.md`. Failure mode: agents copy deprecated patterns into new code. Enforcement: CI grep asserting every file under a listed path carries the LEGACY marker. Owner: the team that owns the migration.
+- **File size:** Boundary: all source files. Failure mode: agents burn tokens on chunked reads and revisit the file per task. Enforcement: eslint `max-lines` at ~400 with per-file overrides requiring a comment. Owner: each package.
+- **Duplication:** Boundary: all packages. Failure mode: fixes land in one copy and drift from the others. Enforcement: `jscpd` threshold in CI. Owner: platform/tooling.

--- a/skills/define-architecture/references/api-design.md
+++ b/skills/define-architecture/references/api-design.md
@@ -7,6 +7,7 @@ Contract-first patterns for REST APIs, module boundaries, and TypeScript interfa
 - Core principles
 - REST patterns
 - TypeScript patterns
+- Agent-facing surfaces
 - Red flags
 
 ## Core Principles
@@ -50,6 +51,14 @@ Verb-to-route mapping: `GET /api/tasks` list (paginated), `POST /api/tasks` crea
 - **Discriminated unions for variants**: model status as a union keyed on a `type` literal (`pending` | `in_progress` | `completed` | `cancelled`), each member carrying only its own fields.
 - **Input/output separation**: keep `CreateTaskInput` (client-supplied) distinct from the full `Task` (adds server-owned `id`, `createdAt`, `updatedAt`, `createdBy`).
 - **Branded types for IDs**: `type TaskId = string & { readonly __brand: 'TaskId' }` so a `UserId` cannot be passed where a `TaskId` is expected.
+
+## Agent-Facing Surfaces
+
+A CLI, SDK, or MCP server that agents drive needs the contract to be discoverable and the output to be machine-parseable, not just human-readable.
+
+- **Self-describing spec.** Expose a no-auth command that emits the interface as a progressive, token-budgeted JSON tree: a top-level overview (commands, global flags, output shape) drills into a subcommand summary, then a full per-command spec (arguments, options, output schema, examples). The agent orients from the contract itself instead of scraping `--help` or docs.
+- **Scriptable output contract.** Make the same flags work on every command: `--json` for structured output, `--format text|json|csv`, `--dry-run` to preview a mutation without applying it, `--quiet` implies JSON. Auto-switch to JSON when stdout is not a TTY, and suppress interactive prompts when piped, so an agent gets structured output by default.
+- **Forward the caller's credential.** When one surface calls another (an assistant calling your API, a gateway forwarding to a service), forward the requesting user's scoped credential, never a service credential. Reject a request on any transport that cannot enforce the credential's scope (for example, a scope-restricted key hitting a WebSocket path that cannot narrow it) rather than silently widening access.
 
 ## Red Flags
 

--- a/skills/define-architecture/references/distributed-correctness.md
+++ b/skills/define-architecture/references/distributed-correctness.md
@@ -14,6 +14,15 @@ Retried calls must collapse into one effect.
 - The check-and-record barrier must be atomic, or concurrent duplicates both pass.
 - Replay the stored result (including a stored error); do not reprocess.
 - A step that already advanced the state re-runs as a no-op, not an error.
+- **Derive the row id from the key** for creates: hash the idempotency key into the new record's primary id (and any batch/transaction ids). A retried create then targets the same id and collapses on the existing unique constraint, so no separate dedupe table is needed.
+
+## Deterministic ids across clients
+
+Offline-first and multi-client systems cannot round-trip to the server to mint an id before writing.
+
+- Compute the id on the client from stable inputs: a UUIDv5 over a frozen namespace constant plus the logical key (for a join row, the two parent ids). Every client derives the same id for the same logical entity, so concurrent inserts of the same edge converge instead of colliding.
+- The namespace constant is load-bearing: changing it regenerates every id in the system. Freeze it and treat a change as a data migration.
+- Keep cross-language ports (a Swift or Kotlin client and the server) in lockstep on the same algorithm and namespace, with a shared test vector, or clients silently disagree on ids.
 
 ## Full resumability
 


### PR DESCRIPTION
## Summary

Distills the SonarSource "code cleanliness vs coding agents" study and the surrounding HN discussion into the define-architecture skill, so the skill can prepare a codebase for agentic coding.

## Skills changed

- **define-architecture**: new reference file `references/agent-friendly-codebase.md`, loaded from the SKILL.md references table and pointed at from Setup step 7 (new), Adoption step 5, and two new gotchas. It covers:
  - Why cleanliness matters for agents: unchanged pass rate, but 7 to 8% fewer tokens and 34% fewer file revisitations, plus convention contagion from unmarked legacy code
  - Deterministic guardrails over prompt rules: knip, jscpd, dependency-cruiser, eslint max-lines/complexity, wired into both pre-commit and CI
  - Legacy quarantine: greppable LEGACY markers plus a docs/legacy.md, referenced from AGENTS.md
  - Locality and naming for cheap traversal; scheduled incremental refactor passes guarded by tests
  - Four convention entries in the craftsmanship.md four-field format, ready to drop into an architecture brief
- SKILL.md description gains "make this codebase agent-friendly" and "set up guardrails for coding agents" triggers; related skills now route to agents-md and tidy

## README updates

- Extended the define-architecture bullet with "and agent-friendly codebase guardrails" (no skill count change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdfcNsxgYPNkxZM3QsFmzB

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdfcNsxgYPNkxZM3QsFmzB)_