### PR TITLE
Add six ax-audit rules for context scoping, bounded tools, and refusal

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Personal voice, blog posts, and voice evaluation live in [ghostwriter](https://g
 ### Quality
 
 - **[ui-audit](./skills/ui-audit/SKILL.md)**: React and Next.js UX audit: 82 rules, 12 playbooks, ship verdict.
-- **[ax-audit](./skills/ax-audit/SKILL.md)**: Agentic experience audit: 23 rules, ship verdict.
+- **[ax-audit](./skills/ax-audit/SKILL.md)**: Agentic experience audit: 29 rules, ship verdict.
 - **[dx-audit](./skills/dx-audit/SKILL.md)**: Libraries, CLIs, and SDKs: root-cause findings, agent-friendly checks.
 - **[typography-audit](./skills/typography-audit/SKILL.md)**: 78 rules: punctuation, fonts, sizing, spacing, hierarchy, pairing.
 - **[optimise-seo](./skills/optimise-seo/SKILL.md)**: Next.js SEO: sitemaps, metadata, structured data, hreflang, CWV.

--- a/skills/agent-skills-creator/scripts/validate.sh
+++ b/skills/agent-skills-creator/scripts/validate.sh
@@ -15,7 +15,10 @@
 
 set -uo pipefail
 
-RESULTS="$(mktemp -t skillvalidate)"
+# An explicit XXXXXX template rather than `mktemp -t skillvalidate`: BSD mktemp
+# treats a bare -t argument as a prefix, GNU mktemp rejects it, so the bare form
+# ran on macOS only and died on Linux and CI.
+RESULTS="$(mktemp "${TMPDIR:-/tmp}/skillvalidate.XXXXXX")"
 trap 'rm -f "$RESULTS"' EXIT
 
 # record <PASS|FAIL|SKIP> <format|house> <check-name> <detail>
@@ -40,7 +43,10 @@ validate_skill() {
   # --- frontmatter: ruby owns YAML parsing and emits its own result lines ---
   ruby -ryaml -e '
     path, folder = ARGV
-    src = File.read(path)
+    # Pin the encoding: File.read honours the locale, so on a box with no
+    # LANG set it reads US-ASCII and any emoji in the body (the verdict line,
+    # for one) raises on the first regex match.
+    src = File.read(path, encoding: "UTF-8")
     m = src.match(/\A---\n(.*?)\n---\n/m)
     # Detail explains a failure, so suppress it on PASS to avoid lines that read
     # as their own contradiction ("PASS name-reserved ... contains a reserved word").
@@ -214,7 +220,7 @@ validate_skill() {
 
   if [ "$found_rules" -eq 1 ]; then
     stated=$(ruby -ryaml -e '
-      src = File.read(ARGV[0])
+      src = File.read(ARGV[0], encoding: "UTF-8")
       m = src.match(/\A---\n(.*?)\n---\n/m)
       d = m ? (YAML.safe_load(m[1])["description"].to_s rescue "") : ""
       puts(d[/(\d+)\s+rules/, 1] || "")

--- a/skills/ax-audit/SKILL.md
+++ b/skills/ax-audit/SKILL.md
@@ -59,8 +59,8 @@ Step notes:
 
 | Layer | Folder | Rules | Question it answers | Category index |
 |---|---|---|---|---|
-| 1: Agent-native architecture | `rules-arch/` | 11 | Can the agent do what the user can do? Are tools atomic? Does the agent know what exists? Is completion explicit? | `rules-arch/_sections.md` |
-| 2: Agentic experience | `rules-ax/` | 12 | Does the agent earn trust? Can the user interrupt, undo, push back? Is memory visible? | `rules-ax/_sections.md` |
+| 1: Agent-native architecture | `rules-arch/` | 16 | Can the agent do what the user can do? Are tools atomic and bounded? Does the agent get the right context, and only that? Is completion explicit? | `rules-arch/_sections.md` |
+| 2: Agentic experience | `rules-ax/` | 13 | Does the agent earn trust? Can the user interrupt, undo, push back? Is memory visible? Can it decline? | `rules-ax/_sections.md` |
 
 Load `rules-arch/<category>-<slug>.md` or `rules-ax/<category>-<slug>.md` when a playbook check names it. Categories: arch = parity, granularity, context, comm; ax = trust, control, context, comm. Both layers share the `comm` and `context` prefixes, but the rules differ: `rules-arch/comm-no-approval-gate.md` (orchestrator code has no gate logic) is not `rules-ax/control-no-approval-gate.md` (approval UI doesn't match the stakes).
 
@@ -99,11 +99,11 @@ Rendered after findings when any agentic feature was detected. Findings serve en
 
 ## Gotchas
 
-- **Scope before rules.** Running all 23 rules repo-wide on a 3-file PR buries a new release-blocker under pre-existing backlog noise; the verdict stops meaning "can this PR merge."
+- **Scope before rules.** Running all 29 rules repo-wide on a 3-file PR buries a new release-blocker under pre-existing backlog noise; the verdict stops meaning "can this PR merge."
 - **The rule's override table is authoritative.** `comm-no-intent-handshake` defaults to `fix-this-sprint` but its table says `release-blocker` on tool execution. Stacking the generic "+1 tier on tool execution" bump on an explicit override double-upgrades backlog findings into blockers.
 - **A stop button not wired to `AbortController.abort()` is a false affordance.** `control-no-escape-hatch` still fails: verify the `abort()` call, not the button label, or the audit passes a UI that lies to users.
 - **Absence checks need a recorded file list.** "Find components lacking X" greps return nothing both when everything passes and when nothing was scanned. List candidate files first (`rg -l <feature-pattern>`), check each for the counter-pattern, and cite the file list as evidence.
-- **`detection: observational` rules cannot fail on grep evidence alone.** `granularity-static-api-mapping`, `trust-no-uncertainty-markers`, `control-over-conversational`, and `comm-no-generative-momentum` need interaction-flow judgment; on static evidence alone, return `unknown` with a reason, not `fail`.
+- **`detection: observational` rules cannot fail on grep evidence alone.** `granularity-static-api-mapping`, `trust-no-uncertainty-markers`, `control-over-conversational`, and `comm-no-generative-momentum` need interaction-flow judgment; on static evidence alone, return `unknown` with a reason, not `fail`. Two `hybrid` rules need the same care for the same reason: `trust-no-refusal-path` needs a trace of a request the agent could not serve, and `comm-no-subagent-attribution` needs one where a branch failed. Report the static half as evidence and mark the rest `unknown` rather than inferring the behaviour from the code.
 - **`ax-audit-ignore:<slug>` comments count as `suppressed`, not `pass`.** Report the count in the verdict block; a suppression with no reason is itself worth a `warn`.
 - **Don't duplicate ui-audit findings.** "Missing loading state" and "form clears on error" are `ui-audit` territory; duplicating them trains engineers to dismiss the whole AX report.
 - **Don't inflate tiers.** `comm-no-generative-momentum` and `granularity-static-api-mapping` default to `backlog`. Promoting cosmetic findings to blocker trains the team to ignore ❌ verdicts.

--- a/skills/ax-audit/references/agent-native-principles.md
+++ b/skills/ax-audit/references/agent-native-principles.md
@@ -17,7 +17,9 @@
 
 ## Tool Design
 
-**Atomic primitives first.** Bash, file ops, storage; prove the architecture before domain tools.
+**Atomic primitives first.** One action per tool, scoped to a domain noun: `read_note`, `update_note`, `list_projects`. Prove the architecture on these before bundling them into workflow tools. Bash, file ops and storage count as primitives only while they operate on a sandbox or scratch data.
+
+**Atomic is not raw.** The same word covers two different things, and only one of them is the principle. An atomic *domain* primitive has a blast radius you can state in a sentence, and `granularity-workflow-shaped-tool` fires when those get bundled away. Raw *substrate* access over production data (arbitrary code eval, a shell on the live host, a SQL or GraphQL passthrough, an untyped SDK call) has the blast radius of the whole system, and makes every tool boundary above it advisory. Ship the first, and audit the second with `rules-arch/granularity-raw-primitive-escape`. The cost of dropping a substrate tool is real: some long-tail requests stop being servable, which is why it pairs with a refusal path rather than a workaround.
 
 **CRUD completeness.** Verify every entity has create, read, update, delete. Common failure: `create_note` + `read_notes` exist but `update_note` and `delete_note` are missing.
 
@@ -60,3 +62,10 @@
 | High | Hard | Explicit approval |
 
 An explicit user request is already approval. Self-modification always requires explicit approval + audit log + rollback.
+
+**Provenance is the third axis.** Stakes and reversibility alone classify by tool name, which is why a gate built from them treats every delete the same. Two questions adjust the row:
+
+- **Did the agent create this in the current conversation?** Deleting a draft it just made is not the same act as deleting a record that existed before the session. Same tool, one tier apart.
+- **Does the target reach outside the workspace?** Posting to an internal thread and posting to one synced with a public repo differ in blast radius, not in stakes as the schema sees them.
+
+A gate that cannot read those two facts can only be tuned by making it stricter, and a gate strict enough to catch the pre-existing delete will also interrupt the draft cleanup. Pass provenance into the checkpoint alongside stakes, so it can be lenient where the agent owns the object and strict where it does not. Audited by `rules-arch/comm-no-approval-gate` (does the checkpoint receive it) and `rules-ax/control-no-approval-gate` (does the treatment change when it does).

--- a/skills/ax-audit/references/feature-playbooks.md
+++ b/skills/ax-audit/references/feature-playbooks.md
@@ -40,34 +40,44 @@ User need: get help from the agent, trust its output, control what it does. Chec
 3. **`context-no-injection`** (rules-arch, release-blocker): sessions initialize with dynamic context (preferences, recent activity, project state), not a bare static prompt.
 4. **`trust-no-confidence-cues`** (fix-this-sprint): output includes rationale or sources so the user can verify correctness.
 5. **`trust-no-uncertainty-markers`** (fix-this-sprint): agent hedges when uncertain rather than presenting guesses as fact.
-6. **`comm-no-intent-handshake`** (fix-this-sprint): non-trivial or destructive actions confirmed before execution.
-7. **`control-over-conversational`** (fix-this-sprint): parallel direct-manipulation controls exist for common actions; users not forced into chat.
-8. **`context-memory-not-visible`** (fix-this-sprint): the user can see and edit what the agent remembers across sessions.
-9. **`comm-no-generative-momentum`** (backlog): blank-canvas entry points offer an agent-generated draft when the agent has the context.
+6. **`trust-no-refusal-path`** (fix-this-sprint): the agent can decline a request it cannot serve, instead of completing the nearest thing it can reach.
+7. **`comm-no-intent-handshake`** (fix-this-sprint): non-trivial or destructive actions confirmed before execution.
+8. **`control-over-conversational`** (fix-this-sprint): parallel direct-manipulation controls exist for common actions; users not forced into chat.
+9. **`context-memory-not-visible`** (fix-this-sprint): the user can see and edit what the agent remembers across sessions.
+10. **`context-unscoped-tool-surface`** (rules-arch, fix-this-sprint): the run carries the tools and procedures this task needs, not the whole product surface.
+11. **`comm-no-generative-momentum`** (backlog): blank-canvas entry points offer an agent-generated draft when the agent has the context.
+12. **`context-volatile-prompt-prefix`** (rules-arch, backlog): per-turn values sit behind the stable prompt, so the provider's prefix cache survives the turn.
 
 ## Agent Tool Execution / Action Panel
 
 User need: understand what the agent is doing, stop it if wrong, trust the outcome. Checks in order:
 
 1. **`trust-no-escalation-path`** (release-blocker): high-stakes actions (deletes, payments, external calls) can hand off to a human first.
-2. **`control-no-approval-gate`** (release-blocker): the approval UI matches the stakes and reversibility of the action.
-3. **`comm-no-approval-gate`** (rules-arch, release-blocker): a gate exists on the orchestrator's execution path and every tool reaches it, not just the ones with a confirmation dialog at the call site.
-4. **`control-no-escape-hatch`** (release-blocker): every completed action has undo or revise; the user is never locked into an agent decision.
-5. **`comm-no-progress-visibility`** (rules-arch, release-blocker): the server emits step-level events during a multi-step run; `comm-no-progress-signal` covers whether the UI shows them.
-6. **`comm-no-completion-signal`** (rules-arch, release-blocker): completion is explicitly signalled (`stop_reason`, completion tool), never inferred from idle time.
-7. **`comm-no-intent-handshake`** (release-blocker on this surface): ambiguous or multi-interpretation requests get a playback/confirmation before the agent acts.
-8. **`context-under-contextual`** (fix-this-sprint on this surface): the agent uses available context (current page, selection, recent actions) instead of asking redundant questions.
-9. **`granularity-static-api-mapping`** (rules-arch, backlog): evolving APIs use discover + access tools, not one hard-coded tool per endpoint.
+2. **`granularity-raw-primitive-escape`** (rules-arch, release-blocker): no raw eval, shell, or query passthrough over production data sits alongside the domain tools, making every boundary above it advisory.
+3. **`control-no-approval-gate`** (release-blocker): the approval UI matches the stakes and reversibility of the action.
+4. **`comm-no-approval-gate`** (rules-arch, release-blocker): a gate exists on the orchestrator's execution path and every tool reaches it, not just the ones with a confirmation dialog at the call site.
+5. **`granularity-permissive-tool-schema`** (rules-arch, release-blocker on this surface): constraints live in the schema, so an invalid target cannot be named in a well-formed call.
+6. **`control-no-escape-hatch`** (release-blocker): every completed action has undo or revise; the user is never locked into an agent decision.
+7. **`comm-no-progress-visibility`** (rules-arch, release-blocker): the server emits step-level events during a multi-step run; `comm-no-progress-signal` covers whether the UI shows them.
+8. **`comm-no-completion-signal`** (rules-arch, release-blocker): completion is explicitly signalled (`stop_reason`, completion tool), never inferred from idle time.
+9. **`comm-no-intent-handshake`** (release-blocker on this surface): ambiguous or multi-interpretation requests get a playback/confirmation before the agent acts.
+10. **`trust-no-refusal-path`** (release-blocker on this surface): an unservable request ends in a stated refusal, not an improvised write to real state.
+11. **`comm-no-subagent-attribution`** (rules-arch, fix-this-sprint): fan-out results carry their branch, and a failed branch is reported rather than filtered into silence.
+12. **`context-under-contextual`** (fix-this-sprint on this surface): the agent uses available context (current page, selection, recent actions) instead of asking redundant questions.
+13. **`granularity-static-api-mapping`** (rules-arch, backlog): evolving APIs use discover + access tools, not one hard-coded tool per endpoint.
 
 ## Agent Configuration / System Prompt Editor
 
 User need: customize agent behavior without breaking it, understand what changed. Checks in order:
 
 1. **`parity-no-tool-parity`** (rules-arch, release-blocker): every UI config option has an agent-accessible equivalent; no GUI-only settings.
-2. **`granularity-workflow-shaped-tool`** (rules-arch, fix-this-sprint): config tools are atomic primitives, not bundled workflows that hide individual options.
-3. **`context-starvation`** (rules-arch, fix-this-sprint): the system prompt injects available resources, tools, and constraints so the agent knows what it can do.
-4. **`context-memory-not-visible`** (fix-this-sprint): the user can see the full context the agent receives, including injected system prompts.
-5. **`context-no-adaptive-canvas`** (backlog): the UI surfaces downstream effects when config changes alter agent behavior.
+2. **`granularity-raw-primitive-escape`** (rules-arch, release-blocker): a config surface cannot register a substrate tool that reaches production data unnarrowed.
+3. **`granularity-workflow-shaped-tool`** (rules-arch, fix-this-sprint): config tools are atomic primitives, not bundled workflows that hide individual options.
+4. **`granularity-permissive-tool-schema`** (rules-arch, fix-this-sprint): tool parameters express their constraints as types, not as prose in the description.
+5. **`context-starvation`** (rules-arch, fix-this-sprint): the system prompt injects available resources, tools, and constraints so the agent knows what it can do.
+6. **`context-unscoped-tool-surface`** (rules-arch, fix-this-sprint): the other end of the same budget, so growing the prompt to satisfy the check above does not ship every procedure on every run.
+7. **`context-memory-not-visible`** (fix-this-sprint): the user can see the full context the agent receives, including injected system prompts.
+8. **`context-no-adaptive-canvas`** (backlog): the UI surfaces downstream effects when config changes alter agent behavior.
 
 ## Agent Dashboard / Status
 
@@ -76,10 +86,11 @@ User need: see what the agent has done, what it's doing now, and what went wrong
 1. **`comm-no-completion-signal`** (rules-arch, release-blocker): completed tasks are explicitly marked done, not left ambiguous.
 2. **`parity-crud-incomplete`** (rules-arch, release-blocker): tasks have full CRUD: create, view, cancel, retry, and delete.
 3. **`comm-no-progress-visibility`** (rules-arch, fix-this-sprint on this surface): the run loop emits step events the dashboard can subscribe to or poll, not just a start and end row.
-4. **`trust-no-confidence-cues`** (fix-this-sprint): completed results include reasoning or a summary of what was done and why.
-5. **`context-memory-not-visible`** (backlog on this surface): the agent's accumulated context is viewable and editable.
-6. **`context-no-checkpoint-resume`** (rules-arch, backlog): interrupted or failed tasks resume from the last checkpoint, not from scratch.
+4. **`comm-no-subagent-attribution`** (rules-arch, fix-this-sprint): a fan-out run reports per-branch state and partial coverage, so a skipped branch is visible rather than absent.
+5. **`trust-no-confidence-cues`** (fix-this-sprint): completed results include reasoning or a summary of what was done and why.
+6. **`context-memory-not-visible`** (backlog on this surface): the agent's accumulated context is viewable and editable.
+7. **`context-no-checkpoint-resume`** (rules-arch, backlog): interrupted or failed tasks resume from the last checkpoint, not from scratch.
 
 ## Coverage
 
-All 23 rules are reachable: 9 via chat, 9 via tool execution, 5 via config, 6 via dashboard, 1 diff-wide (rules repeat across playbooks; unique total = 23). To add a rule, copy `rules-<layer>/_template.md` as the starting structure, then add the rule to at least one playbook or it will never run.
+All 29 rules are reachable: 12 via chat, 13 via tool execution, 8 via config, 7 via dashboard, 1 diff-wide (rules repeat across playbooks; unique total = 29). To add a rule, copy `rules-<layer>/_template.md` as the starting structure, then add the rule to at least one playbook or it will never run.

--- a/skills/ax-audit/rules-arch/_sections.md
+++ b/skills/ax-audit/rules-arch/_sections.md
@@ -11,18 +11,18 @@ The 4 categories of agent-native architecture (Layer 1) audit rules. Each rule f
 
 ## 2. Granularity (granularity)
 
-**Default tier:** mostly fix-this-sprint
-**Why critical:** Tools that bundle decision logic force the agent to accept or reject a whole workflow; atomic primitives let it apply judgment at each step. If behavior changes need code refactoring instead of prompt edits, granularity is too low.
+**Default tier:** mostly fix-this-sprint; release-blocker for raw substrate access
+**Why critical:** Tools that bundle decision logic force the agent to accept or reject a whole workflow; atomic primitives let it apply judgment at each step. If behavior changes need code refactoring instead of prompt edits, granularity is too low. The opposite failure is a tool whose action space is unbounded: a schema that can express an invalid action, or a raw eval, shell, or query passthrough that makes every other tool boundary advisory.
 
 ## 3. Context (context)
 
-**Default tier:** mostly fix-this-sprint
-**Why critical:** An agent that doesn't know what exists or what the user has done asks redundant questions, misses relevant data, and feels unintelligent. Context starvation is the most common reason an agent underperforms despite capable tools.
+**Default tier:** mostly fix-this-sprint to backlog
+**Why critical:** Context is a budget with two ends, and both ends cost accuracy. An agent that doesn't know what exists asks redundant questions and feels unintelligent; an agent handed every tool and every procedure on every run picks the wrong one from a longer list. Placement matters too, since a per-turn value ahead of the stable prompt discards the provider's prefix cache on every call.
 
 ## 4. Communication (comm)
 
-**Default tier:** release-blocker across all three (completion, progress, approval gates)
-**Why critical:** Silent agents feel broken. Heuristic completion detection creates race conditions. Missing progress indicators make users kill and restart tasks. An orchestrator with no gate on its execution path auto-executes whatever destructive tool is registered next, which is why the approval-gate rule blocks a release here rather than waiting a sprint.
+**Default tier:** release-blocker for completion, progress and approval gates; fix-this-sprint for subagent attribution
+**Why critical:** Silent agents feel broken. Heuristic completion detection creates race conditions. Missing progress indicators make users kill and restart tasks. An orchestrator with no gate on its execution path auto-executes whatever destructive tool is registered next, which is why the approval-gate rule blocks a release here rather than waiting a sprint. Fan-out adds a quieter version: a branch that failed and was filtered out reports as coverage that never happened.
 
 ---
 
@@ -30,12 +30,15 @@ The 4 categories of agent-native architecture (Layer 1) audit rules. Each rule f
 
 ```
 parity-no-tool-parity             parity-crud-incomplete            parity-orphan-ui-action
-granularity-workflow-shaped-tool   granularity-static-api-mapping
+granularity-workflow-shaped-tool   granularity-static-api-mapping    granularity-raw-primitive-escape
+granularity-permissive-tool-schema
 context-starvation                 context-no-injection              context-no-checkpoint-resume
+context-unscoped-tool-surface      context-volatile-prompt-prefix
 comm-no-completion-signal          comm-no-progress-visibility       comm-no-approval-gate
+comm-no-subagent-attribution
 ```
 
-Total: 11 rules.
+Total: 16 rules.
 
 ---
 
@@ -46,7 +49,12 @@ Within this layer, these pairs sit close enough to double-report. Pick one:
 - **no-tool-parity + orphan-ui-action**: same defect, different scope. `parity-no-tool-parity` sweeps the shipped codebase; `parity-orphan-ui-action` looks only at the diff. A capability the PR introduced is the orphan finding; anything older is the parity finding, never both.
 - **crud-incomplete + no-tool-parity**: `parity-crud-incomplete` is entity-level (this noun is missing an operation), `parity-no-tool-parity` is handler-level (this endpoint has no tool). A missing `update_note` matches both: report the CRUD finding, which names the operation.
 - **workflow-shaped-tool + static-api-mapping**: opposite ends of one axis. Too coarse (one tool making domain decisions) versus too many too-thin tools (one per endpoint, no discovery). They should not fire on the same tool; if they do, re-read the tool.
+- **raw-primitive-escape + permissive-tool-schema**: both say the action space is unbounded, at different layers. A `z.string()` where an enum belongs is the schema finding; a tool whose whole input is code or a query is the substrate finding. An `eval(code: string)` tool matches both greps: report the substrate finding, which names the real blast radius.
+- **raw-primitive-escape + workflow-shaped-tool**: these look like opposites and are not. Dropping a substrate tool does not mean bundling its callers into a workflow tool; it means adding a bounded domain tool for the gap. If removing the first is about to trip the second, the replacement is shaped wrong.
 - **context-starvation + context-no-injection**: one static prompt trips both greps. Report `context-starvation` for the missing what-exists block, and `context-no-injection` only when cross-session state is separately absent.
+- **context-starvation + context-unscoped-tool-surface**: the two ends of the context budget. A prompt can genuinely fail both, and it is worth reporting both, because the fix is one restructure (a small resident core plus on-demand procedures) rather than two opposing edits.
+- **context-unscoped-tool-surface + context-volatile-prompt-prefix**: size versus placement. The first says too much ships every run; the second says what ships is ordered so none of it caches. Fixing placement does not shrink the prompt, and shrinking it does not fix placement.
+- **comm-no-subagent-attribution + comm-no-progress-visibility**: a fan-out that emits nothing at all fails the progress rule, and attribution is moot until it does. Fix the emission first, then ask whether the events name their branch.
 - **no-completion-signal + no-progress-visibility**: both audit the orchestrator's event contract, at the end of the run and during it. A loop that emits nothing fails both; fix the emission once and re-run.
 
 Across layers, `rules-arch` owns the code path and `rules-ax` owns what the user sees on it:

--- a/skills/ax-audit/rules-arch/comm-no-approval-gate.md
+++ b/skills/ax-audit/rules-arch/comm-no-approval-gate.md
@@ -6,7 +6,7 @@ defaultTier: release-blocker
 surfaces: agent-tool-execution, agent-chat
 agent-native-principle: Parity (agent-UI communication)
 detection: hybrid
-related: comm-no-progress-visibility, control-no-approval-gate
+related: comm-no-progress-visibility, control-no-approval-gate, granularity-raw-primitive-escape, granularity-permissive-tool-schema
 ---
 
 ## Orchestrator executes high-stakes tools with no gate on the code path
@@ -28,6 +28,7 @@ A chat surface ships a confirmation modal for the three delete tools it knows ab
 2. Identify destructive/financial/external operations: send, delete, publish, deploy, charge, transfer.
 3. Check whether an approval handler sits between dispatch and execution on that path, and whether it is reached for every tool or only for named ones.
 4. Check what happens to a tool with no stakes metadata: defaulting to auto-approve is a fail even when today's registry is fully labelled.
+5. Check what the checkpoint receives. Tool name and arguments alone cannot express provenance (did the agent create this object this conversation, does the target reach outside the workspace), so a gate given only those can be tuned by strictness and nothing else. See the third axis in `references/agent-native-principles.md`.
 
 **Runtime signals:** a destructive tool added to the registry with no other change executes without prompting.
 

--- a/skills/ax-audit/rules-arch/comm-no-completion-signal.md
+++ b/skills/ax-audit/rules-arch/comm-no-completion-signal.md
@@ -6,7 +6,7 @@ defaultTier: release-blocker
 surfaces: agent-tool-execution, agent-dashboard
 agent-native-principle: Parity (agent-UI communication)
 detection: code-auditable
-related: comm-no-progress-visibility
+related: comm-no-progress-visibility, comm-no-subagent-attribution, context-no-checkpoint-resume
 ---
 
 ## Agent completion detected by heuristic instead of explicit signal

--- a/skills/ax-audit/rules-arch/comm-no-progress-visibility.md
+++ b/skills/ax-audit/rules-arch/comm-no-progress-visibility.md
@@ -6,7 +6,7 @@ defaultTier: release-blocker
 surfaces: agent-chat, agent-tool-execution, agent-dashboard
 agent-native-principle: Parity (agent-UI communication)
 detection: code-auditable
-related: comm-no-completion-signal, comm-no-approval-gate, comm-no-progress-signal
+related: comm-no-completion-signal, comm-no-approval-gate, comm-no-progress-signal, comm-no-subagent-attribution
 ---
 
 ## Orchestrator emits no progress events during execution

--- a/skills/ax-audit/rules-arch/comm-no-subagent-attribution.md
+++ b/skills/ax-audit/rules-arch/comm-no-subagent-attribution.md
@@ -1,0 +1,89 @@
+---
+title: Fan-out reports one aggregate with no per-branch attribution
+slug: comm-no-subagent-attribution
+category: comm
+defaultTier: fix-this-sprint
+surfaces: agent-tool-execution, agent-dashboard
+agent-native-principle: Parity (agent-UI communication)
+detection: hybrid
+related: comm-no-progress-visibility, comm-no-completion-signal, context-no-checkpoint-resume, comm-no-progress-signal
+---
+
+## Fan-out reports one aggregate with no per-branch attribution
+
+The parent spawns several sub-runs, awaits them together, and emits one result. Nothing downstream can say which branch produced which finding, which branch is still running, or which one failed. A rejected branch resolves to null, gets filtered out, and the summary reads as complete coverage of work that never happened.
+
+Scope: `comm-no-progress-visibility` asks whether the run loop emits step events at all. This rule assumes it does and asks whether those events carry a branch identity. A single-threaded agent cannot fail this rule.
+
+## What goes wrong
+
+A review agent fans one agent per file across a 30-file diff. Four sub-runs hit a rate limit and reject. The gather call collects results, drops the empty ones, and the parent reports "reviewed the diff, 6 findings". Six is the count from 26 files. Nobody learns that four were skipped, because the only place that fact existed was a rejected promise inside a `Promise.allSettled` nobody read.
+
+## Detection
+
+**Surfaces:** agent-tool-execution, agent-dashboard
+
+**Static signals:**
+1. Find fan-out sites: `Promise.all`, `Promise.allSettled`, a task queue, or a loop that spawns runs. Record file and line.
+2. At each, check whether a branch identity (index, label, subject) is carried into the result, or whether results are positional only.
+3. Check the settle handling. `.filter(Boolean)`, `.filter(r => r.status === "fulfilled")` or a bare `catch` with no re-emit collapses failures into silence.
+4. Check whether events emitted during the fan-out carry that identity, so a consumer can attribute progress to a branch.
+5. Fail when a fan-out drops branch identity or swallows a rejected branch. Record the site and how many branches it spawns.
+
+**Concrete commands:**
+```bash
+rg -n '(Promise\.all|Promise\.allSettled|allSettled)' --type=ts src/
+rg -n '\.filter\((Boolean|r => r\.status)' --type=ts src/
+rg -n '(subagent|subAgent|spawnAgent|delegate|fanOut)' --type=ts src/
+```
+
+**Judgment signals:**
+- A results array typed as `T[]` rather than `{ branch: string; result: T }[]` has already lost the attribution, whatever the UI does with it.
+- Per-branch events that all share the parent's run id are indistinguishable downstream, which is the same defect one layer along.
+
+**False-positive guards:**
+- Skip files with `// ax-audit-ignore:comm-no-subagent-attribution`.
+- Skip fan-out over homogeneous work where the branch is genuinely uninteresting, such as retrying one idempotent call three times.
+- Skip sites that re-emit failures into the parent's result, which is the corrected shape.
+- Skip test files and eval harnesses.
+
+## Fix
+
+Carry the branch through the result and report partial coverage as a first-class outcome rather than a shorter list.
+
+```ts
+// before: positional results, failures filtered away
+const findings = (await Promise.all(files.map(review))).filter(Boolean).flat();
+
+// after: identity survives, and so does the failure
+const settled = await Promise.allSettled(files.map(review));
+const branches = settled.map((r, i) => ({
+  file: files[i],
+  ...(r.status === "fulfilled" ? { findings: r.value } : { failed: String(r.reason) }),
+}));
+emit({ type: "fanout.complete", covered: branches.filter(b => !b.failed).length, total: files.length, branches });
+```
+
+## Default tier and overrides
+
+**Defaults to:** `fix-this-sprint`
+
+| Surface | Tier |
+|---|---|
+| Agent tool execution | fix-this-sprint |
+| Agent dashboard | fix-this-sprint |
+
+The rows do not taper. The defect is in the orchestrator's event contract, so a dashboard cannot render attribution the server never emitted, and neither surface can compensate for the other.
+
+## Examples
+
+**Anti-pattern (fails):** `const results = (await Promise.all(tasks)).filter(Boolean)` at the fan-out site, a `Finding[]` return type, and no event carrying a branch id between spawn and completion.
+
+**Applied (passes):** results are `{ branch, findings | failed }`, the completion event reports `covered` against `total`, and the summary says which branches were skipped.
+
+## Suppression
+
+```ts
+// ax-audit-ignore:comm-no-subagent-attribution, three retries of one idempotent read, the branch carries no meaning
+const [a] = await Promise.all([fetchOnce(), fetchOnce(), fetchOnce()]);
+```

--- a/skills/ax-audit/rules-arch/context-no-checkpoint-resume.md
+++ b/skills/ax-audit/rules-arch/context-no-checkpoint-resume.md
@@ -6,7 +6,7 @@ defaultTier: backlog
 surfaces: agent-tool-execution, agent-dashboard
 agent-native-principle: Improvement Over Time
 detection: hybrid
-related: comm-no-completion-signal
+related: comm-no-completion-signal, comm-no-subagent-attribution, context-no-injection
 ---
 
 ## Long-running agent with no checkpoint/resume

--- a/skills/ax-audit/rules-arch/context-no-injection.md
+++ b/skills/ax-audit/rules-arch/context-no-injection.md
@@ -6,7 +6,7 @@ defaultTier: fix-this-sprint
 surfaces: agent-chat, agent-tool-execution
 agent-native-principle: Improvement Over Time
 detection: code-auditable
-related: context-starvation, context-no-checkpoint-resume
+related: context-starvation, context-no-checkpoint-resume, context-unscoped-tool-surface, context-volatile-prompt-prefix
 ---
 
 ## Agent session starts without knowing what data exists
@@ -55,6 +55,8 @@ async function createSession(userId: string) {
   };
 }
 ```
+
+The order matters as much as the content. `STATIC_PROMPT` comes first so the provider's prefix cache still matches up to the point the session's own context begins; leading with the dynamic part invalidates the cache on every turn and trips `context-volatile-prompt-prefix`. Inject an inventory rather than the full contents, so satisfying this rule does not trip `context-unscoped-tool-surface`.
 
 ## Default tier and overrides
 

--- a/skills/ax-audit/rules-arch/context-starvation.md
+++ b/skills/ax-audit/rules-arch/context-starvation.md
@@ -6,12 +6,14 @@ defaultTier: fix-this-sprint
 surfaces: agent-chat, agent-tool-execution, agent-config
 agent-native-principle: Improvement Over Time
 detection: code-auditable
-related: context-no-injection
+related: context-no-injection, context-unscoped-tool-surface, context-volatile-prompt-prefix, context-under-contextual
 ---
 
 ## System prompt missing resource injection
 
 System prompt says "You are a helpful assistant" with zero dynamic context. Agent asks "What files do you have?" instead of using them. Violates Improvement Over Time: agents should accumulate context, not start blind.
+
+Scope: context is a budget with two ends, and this rule guards the floor. Satisfying it by pasting every resource and procedure into the always-on prompt trips `context-unscoped-tool-surface` at the other end. Inject an inventory of what exists, plus a way to reach the detail on demand, rather than the detail itself.
 
 ## What goes wrong
 

--- a/skills/ax-audit/rules-arch/context-unscoped-tool-surface.md
+++ b/skills/ax-audit/rules-arch/context-unscoped-tool-surface.md
@@ -1,0 +1,86 @@
+---
+title: Every tool and the whole prompt ship on every run
+slug: context-unscoped-tool-surface
+category: context
+defaultTier: fix-this-sprint
+surfaces: agent-chat, agent-tool-execution, agent-config
+agent-native-principle: Context (progressive disclosure)
+detection: code-auditable
+related: context-starvation, context-no-injection, context-volatile-prompt-prefix, granularity-permissive-tool-schema
+---
+
+## Every tool and the whole prompt ship on every run
+
+The registry hands the model every tool it owns and the system prompt carries every procedure the product supports, whatever the user asked for. Each new capability then taxes every unrelated request: more schemas to read past, more instructions competing for attention, and a larger surface for the model to pick the wrong thing from. Violates Context, which is a two-sided budget rather than a floor to clear.
+
+Scope: this rule fires on the absence of any scoping mechanism. `context-starvation` fires on the opposite defect, a prompt that never says what exists. A codebase can fail both, and the fix is the same restructure: a small stable core plus procedures loaded when the task calls for them.
+
+## What goes wrong
+
+A support agent grows from 6 tools to 40 over two quarters. Nothing regresses in review, because each PR adds one tool. Then billing questions start resolving as refunds: `issue_refund` and `explain_charge` are adjacent in a 40-schema block, and the prompt's refund policy sits 3,000 tokens from the billing section that qualifies it. Nobody changed the refund logic. The context around it got noisier.
+
+## Detection
+
+**Surfaces:** agent-chat, agent-tool-execution, agent-config
+
+**Static signals:**
+1. Count registered tools at the call site that builds the model request. Record the number.
+2. Measure the always-on system prompt in characters, including anything concatenated into it at request time.
+3. Look for any scoping mechanism: a per-request tool filter, a load-on-demand procedure loader, prompt sections assembled from the channel or route, or subagents with their own prompt and tools.
+4. Fail when steps 1 and 2 are both large (roughly 20+ tools or 12,000+ characters of prompt) and step 3 finds nothing. Report the counts as evidence either way.
+
+**Concrete commands:**
+```bash
+rg 'tools\s*[:=]\s*[\[{]' --type=ts -A 40 src/        # what gets handed to the model
+rg -c '' src/prompts/*.md src/**/instructions.md      # always-on prompt size
+rg '(activeTools|toolChoice|filterTools|allowedTools|loadSkill|load_skill|defineSkill)' --type=ts src/
+```
+
+**False-positive guards:**
+- Skip files with `// ax-audit-ignore:context-unscoped-tool-surface`.
+- Skip agents under the thresholds; a 6-tool agent with one prompt is correctly shaped and scoping it would only add indirection.
+- Skip a registry that is already filtered upstream: confirm what reaches the model request, not what the module exports.
+- Skip subagent definitions, which are themselves the scoping mechanism, and test fixtures.
+
+## Fix
+
+Keep a small stable core in the always-on prompt and move procedures behind a loader the model calls when a task matches. Tool sets follow the same split where the framework allows a per-request filter.
+
+```ts
+// before: one prompt, every tool, every turn
+const result = await run({ system: ENTIRE_PROMPT, tools: allTools });
+
+// after: stable core plus what this run actually needs
+const result = await run({
+  system: CORE_PROMPT,                              // identity, voice, standing rules
+  tools: toolsFor(surface),                         // scoped by the invocation context
+  skills: registry,                                 // procedures the model loads on demand
+});
+```
+
+Which procedures earn a place in the core is a judgment call: anything the agent must honour on a turn where it never thinks to load it stays resident.
+
+## Default tier and overrides
+
+**Defaults to:** `fix-this-sprint`
+
+| Surface | Tier |
+|---|---|
+| Agent tool execution | fix-this-sprint |
+| Agent chat | fix-this-sprint |
+| Agent config | fix-this-sprint |
+
+The rows do not taper. This is a shape problem in how the request is assembled, so it costs the same on every surface that assembles one, and it degrades accuracy rather than safety.
+
+## Examples
+
+**Anti-pattern (fails):** `run({ system: PROMPT, tools: allTools })` at the single call site, 40 entries in `allTools`, an 18,000-character prompt file, and no hit for `activeTools|load_skill|defineSkill` anywhere in the repo.
+
+**Applied (passes):** the same call site reads `toolsFor(ctx.surface)`, the resident prompt is 4,000 characters of identity and standing rules, and six procedure files sit behind a loader the model can call mid-run.
+
+## Suppression
+
+```ts
+// ax-audit-ignore:context-unscoped-tool-surface, single-purpose extraction agent, all 24 tools are one workflow
+const agent = createAgent({ system: PROMPT, tools: extractionTools });
+```

--- a/skills/ax-audit/rules-arch/context-volatile-prompt-prefix.md
+++ b/skills/ax-audit/rules-arch/context-volatile-prompt-prefix.md
@@ -1,0 +1,82 @@
+---
+title: Per-turn volatile values sit ahead of the stable prompt
+slug: context-volatile-prompt-prefix
+category: context
+defaultTier: backlog
+surfaces: agent-chat, agent-tool-execution
+agent-native-principle: Context (stable prefix)
+detection: code-auditable
+related: context-no-injection, context-unscoped-tool-surface, context-starvation
+---
+
+## Per-turn volatile values sit ahead of the stable prompt
+
+Providers cache a request by its longest matching prefix, so the cache survives only up to the first byte that changed. A timestamp, a request id, or a token counter rendered at the top of the system prompt moves that boundary to zero on every turn: the whole prompt and every tool schema behind it are reprocessed as new input. The content is usually right and the position is wrong, which is why this survives review.
+
+Scope: this rule is about placement, not about whether dynamic context belongs in the prompt at all. `context-no-injection` asks for that content to exist. This rule asks for it to sit after everything stable, so asking for both is not a contradiction.
+
+## What goes wrong
+
+An agent renders `Current time: 2026-08-10T09:14:33Z` as line one of a 20,000-token system prompt, so the model can resolve "tomorrow". It works. Six months later the bill is three times what the traffic predicts and every turn reports zero cache reads, because a prompt whose first line changes every second has no reusable prefix. Moving that line below the tool schemas changes no behaviour and restores the cache.
+
+## Detection
+
+**Surfaces:** agent-chat, agent-tool-execution
+
+**Static signals:**
+1. Find where the system prompt is assembled and record the order of its parts.
+2. In each part that lands before the stable body, look for values that differ per turn: clock reads, `Date`, `Math.random`, uuid mints, counters, cursors, per-request ids, "messages so far".
+3. Confirm the stable body is actually large enough to matter, that is, tool schemas and standing instructions sit behind the volatile part.
+4. Fail when a per-turn value precedes a stable block. Record the file, the line, and which value moves.
+
+**Concrete commands:**
+```bash
+rg -n '(new Date|Date\.now|toISOString|randomUUID|Math\.random|performance\.now)' --type=ts src/ \
+  | rg -i '(prompt|system|instruction|context)'
+rg -n 'system\s*[:=]' --type=ts -A 15 src/          # read the assembly order
+```
+
+**False-positive guards:**
+- Skip files with `// ax-audit-ignore:context-volatile-prompt-prefix`.
+- Skip volatile values already placed after the stable body or carried in the user message, which is the corrected shape.
+- Skip build-time values baked into a compiled manifest: those are stable across turns even though the expression looks dynamic.
+- Skip providers and gateways with no prefix caching, but say so in the finding rather than passing silently.
+- Skip test fixtures and eval harnesses.
+
+## Fix
+
+Order the request stable-to-volatile, and put anything that changes per turn at the tail or in the turn's own message.
+
+```ts
+// before: the cache boundary is line 1
+const system = `Current time: ${new Date().toISOString()}\n\n${CORE_PROMPT}`;
+
+// after: the stable prefix is reusable, the clock rides at the end
+const system = `${CORE_PROMPT}\n\n${TOOL_NOTES}\n\n<runtime>\nCurrent time: ${now}\n</runtime>`;
+```
+
+A tool the model can call for the current time is often better still: it removes the value from the prompt entirely and costs a round trip only on turns that need it.
+
+## Default tier and overrides
+
+**Defaults to:** `backlog`
+
+| Surface | Tier |
+|---|---|
+| Agent tool execution | backlog |
+| Agent chat | backlog |
+
+The rows do not taper. This is a cost and latency defect with no user-visible failure, so it does not rise on tool execution the way a safety rule does. Promote it only when the finding comes with a measured cache-miss rate.
+
+## Examples
+
+**Anti-pattern (fails):** `system` is built as a template literal whose first interpolation is `new Date().toISOString()`, followed by 18,000 characters of standing instructions and tool notes.
+
+**Applied (passes):** `CORE_PROMPT` is a module constant, the only interpolation happens inside a trailing `<runtime>` block, and the assembly function has a comment naming the cache boundary.
+
+## Suppression
+
+```ts
+// ax-audit-ignore:context-volatile-prompt-prefix, prompt is 400 tokens, no cacheable prefix to protect
+const system = `${now}\n${TINY_PROMPT}`;
+```

--- a/skills/ax-audit/rules-arch/granularity-permissive-tool-schema.md
+++ b/skills/ax-audit/rules-arch/granularity-permissive-tool-schema.md
@@ -1,0 +1,83 @@
+---
+title: Tool schema lets the model express an invalid action
+slug: granularity-permissive-tool-schema
+category: granularity
+defaultTier: fix-this-sprint
+surfaces: agent-tool-execution, agent-config
+agent-native-principle: Granularity (constraints in the schema)
+detection: code-auditable
+related: granularity-workflow-shaped-tool, granularity-raw-primitive-escape, comm-no-approval-gate, context-unscoped-tool-surface
+---
+
+## Tool schema lets the model express an invalid action
+
+A parameter takes a free-form string where the domain has a closed set, or the constraint that makes a call safe lives in the description rather than the type. The model can then name a target that should not be reachable, and the call is well-formed, so nothing rejects it. A schema is the one place a rule is enforced before the model gets a chance to be creative; prose next to it is a suggestion.
+
+The sharpest version is a parameter the server ignores when it does not recognise it. A wrong value then produces no error, a plausible-looking result, and an answer built on a filter that never applied.
+
+## What goes wrong
+
+A calendar tool takes `calendarId: string` with a description saying new events belong on the personal calendar. It works for a year. Then a work-sounding request arrives, the model reads the subject rather than the rule, and the event lands on a calendar shared with someone else. The same tool with `z.enum([PERSONAL, LEGACY])` makes that outcome unrepresentable, and the diff is one line.
+
+## Detection
+
+**Surfaces:** agent-tool-execution, agent-config
+
+**Static signals:**
+1. List every tool's input schema and record each parameter's type.
+2. Flag string parameters that name a target from a closed set: ids, repos, calendars, environments, channels, roles, modes, tables.
+3. Read the tool description for constraints stated in prose, and check whether the schema restates them. A constraint that appears only in prose is the finding.
+4. Check optional parameters that gate a destructive branch, and unbounded numbers on anything paginated or charged.
+5. Fail when a constraint the code depends on is unrepresented in the schema. Record the tool, the parameter, and the prose that carries the rule today.
+
+**Concrete commands:**
+```bash
+rg -n 'z\.string\(\)' --type=ts -B 3 src/tools/ | rg -i '(id|repo|calendar|env|channel|role|mode|table|target)'
+rg -n '(z\.enum|z\.literal|z\.union|z\.discriminatedUnion)' --type=ts src/tools/
+rg -n 'describe\(' --type=ts src/tools/ | rg -i '(never|only|must|do not|always|defaults to)'
+```
+
+**False-positive guards:**
+- Skip files with `// ax-audit-ignore:granularity-permissive-tool-schema`.
+- Skip genuinely open sets: free text, search queries, file contents, commit messages, user-authored prose.
+- Skip identifiers minted elsewhere and passed straight back, where an enum would go stale on every new record.
+- Skip a string already narrowed at the boundary by a runtime allowlist that refuses with a named reason; note it as a weaker but valid form.
+- Skip test fixtures and generated clients.
+
+## Fix
+
+Move the constraint from the description into the type, and refuse rather than default when a value cannot be resolved.
+
+```ts
+// before: the rule is prose, so the model can decline to follow it
+repo: z.string().default(VAULT_REPO).describe("owner/name; defaults to the vault repo")
+
+// after: the rule is the type
+repo: z.enum([VAULT_REPO, AGENT_REPO]).default(VAULT_REPO)
+```
+
+Where the set is known only at runtime, validate at the boundary and return a refusal naming the allowed values, so a wrong guess surfaces as an error rather than a silently ignored argument.
+
+## Default tier and overrides
+
+**Defaults to:** `fix-this-sprint`
+
+| Surface | Tier |
+|---|---|
+| Agent tool execution | release-blocker |
+| Agent config | fix-this-sprint |
+
+Tool execution takes the bump because that is where a permissive parameter becomes a wrong write. On a config surface the same schema is edited by a human who can see the field.
+
+## Examples
+
+**Anti-pattern (fails):** `repo: z.string()` on a tool that commits to GitHub, with the real constraint living in a sentence of the tool description, and no runtime check on the value.
+
+**Applied (passes):** `calendarId: z.enum([BLODE_CO, GMAIL])` on a create-event tool, so the read-only shared calendar cannot be named at all, and the tool rejects any other id before it reaches the API.
+
+## Suppression
+
+```ts
+// ax-audit-ignore:granularity-permissive-tool-schema, ids are minted per record, an enum would go stale hourly
+issueId: z.string().describe("Linear issue id")
+```

--- a/skills/ax-audit/rules-arch/granularity-raw-primitive-escape.md
+++ b/skills/ax-audit/rules-arch/granularity-raw-primitive-escape.md
@@ -1,0 +1,82 @@
+---
+title: Raw substrate access sits alongside the domain tools
+slug: granularity-raw-primitive-escape
+category: granularity
+defaultTier: release-blocker
+surfaces: agent-tool-execution, agent-config
+agent-native-principle: Granularity (bounded action space)
+detection: code-auditable
+related: granularity-workflow-shaped-tool, granularity-permissive-tool-schema, comm-no-approval-gate, trust-no-refusal-path
+---
+
+## Raw substrate access sits alongside the domain tools
+
+The agent can reach the layer underneath its own tools: arbitrary JavaScript in a page, a shell against real data, a raw SQL or GraphQL passthrough, an untyped SDK call. Every tool boundary above it becomes advisory, since anything a domain tool refuses can be done a level down. The failure is not the first request that uses it; it is the long-tail request with no obvious path to completion, where the model reaches for the substrate and improvises.
+
+Scope: atomic primitives are the right shape for a domain tool, and `granularity-workflow-shaped-tool` fires when they are bundled away. That is a different axis from this one. `read_note` and `update_note` are atomic domain primitives with a bounded blast radius; `evaluate(js)` and `query(sql)` are substrate access whose blast radius is the whole system. Atomic-first argues for the former and says nothing in favour of the latter. Sandboxed primitives over scratch data, which is what a coding agent's `bash` operates on, are not in scope: the test is whether the reachable data is production.
+
+## What goes wrong
+
+A group chat agent mounts a browser extension for research. Twenty of its tools navigate and read. The twenty-first evaluates arbitrary JavaScript on any domain, because the package ships it and nothing narrowed the mount. No user story asked for it, no eval covers it, and any member of the chat can steer it. The agent behaves for months, which is the problem: the capability is only exercised the day someone asks for something the other twenty tools cannot do.
+
+## Detection
+
+**Surfaces:** agent-tool-execution, agent-config
+
+**Static signals:**
+1. List the registered tools and mark any whose input is code, a query, a command line, or a URL plus a script.
+2. For each, trace what it reaches. Production database, live account, real filesystem, or an authenticated browser session is in scope; a disposable sandbox over scratch data is not.
+3. Check for a narrowing layer: a domain allowlist, a statement-kind restriction, a network policy that is not allow-all, a read-only credential.
+4. Fail when a substrate tool reaches production data with no narrowing layer. Record the tool name, the file, and what it reaches.
+
+**Concrete commands:**
+```bash
+rg -n '(eval|new Function|vm\.runIn|child_process|execSync|spawnSync)' --type=ts src/tools/
+rg -n '(rawQuery|\.query\(|executeSql|graphql\(|gql`)' --type=ts src/tools/
+rg -n '(allowedDomains|allowlist|readOnly|permissions|networkPolicy)' --type=ts src/
+```
+
+**False-positive guards:**
+- Skip files with `// ax-audit-ignore:granularity-raw-primitive-escape`.
+- Skip sandboxed execution over scratch or fixture data with no production credential in reach.
+- Skip parameterised queries against a read-only replica with a restricted role, which is a narrowing layer.
+- Skip developer-only tools behind an operator flag the agent's own principal cannot set.
+- Skip test files, seed scripts, and migrations.
+
+## Fix
+
+Remove the substrate tool, or narrow it until its worst case is describable in one sentence. When neither is possible, name the gap the tool was covering and add a domain tool for it.
+
+```ts
+// before: anything the domain tools refuse is reachable one level down
+tools: [...domainTools, evaluateJs, rawSqlQuery]
+
+// after: the gap is a named capability with its own bounded tool
+tools: [...domainTools, extractTableFromPage]
+```
+
+Losing the escape hatch means some long-tail requests can no longer be served. That is the trade: `trust-no-refusal-path` covers saying so plainly instead of improvising.
+
+## Default tier and overrides
+
+**Defaults to:** `release-blocker`
+
+| Surface | Tier |
+|---|---|
+| Agent tool execution | release-blocker |
+| Agent config | release-blocker |
+
+The rows do not taper. A substrate tool is reachable from wherever it is registered, so exposing it through a config surface is the same defect with the same blast radius.
+
+## Examples
+
+**Anti-pattern (fails):** a tool registry exporting `browser__evaluate` with no `allowedDomains` set anywhere in the mount, or a `runQuery(sql: string)` tool authenticated as the application's own database role.
+
+**Applied (passes):** the browser mount overrides the slot to drop the evaluate tool and pins a domain allowlist; database reads go through named query tools whose parameters are typed and whose role is read-only.
+
+## Suppression
+
+```ts
+// ax-audit-ignore:granularity-raw-primitive-escape, sandbox holds fixture data only, no credential reaches it
+const shell = defineTool({ name: "bash", execute: runInSandbox });
+```

--- a/skills/ax-audit/rules-arch/granularity-workflow-shaped-tool.md
+++ b/skills/ax-audit/rules-arch/granularity-workflow-shaped-tool.md
@@ -6,7 +6,7 @@ defaultTier: fix-this-sprint
 surfaces: agent-tool-execution, agent-config
 agent-native-principle: Granularity
 detection: hybrid
-related: granularity-static-api-mapping
+related: granularity-static-api-mapping, granularity-raw-primitive-escape, granularity-permissive-tool-schema
 ---
 
 ## Tool bundles decision logic instead of being atomic

--- a/skills/ax-audit/rules-arch/parity-crud-incomplete.md
+++ b/skills/ax-audit/rules-arch/parity-crud-incomplete.md
@@ -6,7 +6,7 @@ defaultTier: release-blocker
 surfaces: agent-tool-execution, agent-config, agent-dashboard
 agent-native-principle: Parity
 detection: code-auditable
-related: parity-no-tool-parity
+related: parity-no-tool-parity, parity-orphan-ui-action
 ---
 
 ## Entity with incomplete CRUD tool coverage

--- a/skills/ax-audit/rules-ax/_sections.md
+++ b/skills/ax-audit/rules-ax/_sections.md
@@ -7,7 +7,7 @@ This file defines the 4 categories of agentic experience audit rules. Each rule 
 ## 1. Trust & Transparency (trust)
 
 **Default tier:** mostly fix-this-sprint; release-blocker for missing escalation paths
-**Why critical:** Users won't trust an agent, even when it's right, unless they can see why it decided what it did. Confident wrong answers without uncertainty markers or escalation paths cause permanent trust damage that future accuracy can't recover.
+**Why critical:** Users won't trust an agent, even when it's right, unless they can see why it decided what it did. Confident wrong answers without uncertainty markers or escalation paths cause permanent trust damage that future accuracy can't recover. The same damage arrives from the other direction when the agent has no way to stop: with every path ending in an action, a request it cannot serve becomes a speculative one that reads exactly like a real answer.
 
 ## 2. Control & Recovery (control)
 
@@ -30,12 +30,13 @@ This file defines the 4 categories of agentic experience audit rules. Each rule 
 
 ```
 trust-no-confidence-cues          trust-no-uncertainty-markers      trust-no-escalation-path
+trust-no-refusal-path
 control-no-escape-hatch           control-no-approval-gate          control-over-conversational
 context-memory-not-visible        context-no-adaptive-canvas        context-under-contextual
 comm-no-intent-handshake          comm-no-progress-signal           comm-no-generative-momentum
 ```
 
-Total: 12 rules.
+Total: 13 rules.
 
 ---
 
@@ -44,6 +45,8 @@ Total: 12 rules.
 These pairings often co-fire on the same surface:
 
 - **no-confidence-cues + no-uncertainty-markers**: both address "why should I trust this." Different targets: rationale vs. hedging.
+- **no-uncertainty-markers + no-refusal-path**: a spectrum, not a pair. Hedging is for an answer worth giving with a caveat; refusal is for one not worth giving. Report the refusal finding when the agent completed an action it had no safe path to, and the hedging finding when the answer was fine but rendered as certain.
+- **no-refusal-path + no-escalation-path**: escalation is the stronger fix and supersedes refusal where a human queue exists. On a surface with no one to escalate to, refusal is the whole remedy; do not report both as separate work.
 - **no-escape-hatch + no-approval-gate**: for autonomous actions, both fire. Approval gate may partially satisfy escape hatch.
 - **no-progress-signal + no-intent-handshake**: long-running tasks that didn't confirm scope AND show no progress are doubly opaque.
 - **memory-not-visible + under-contextual**: complementary. One says the agent knows things the user can't see; the other says it doesn't know things it should.

--- a/skills/ax-audit/rules-ax/comm-no-intent-handshake.md
+++ b/skills/ax-audit/rules-ax/comm-no-intent-handshake.md
@@ -6,7 +6,7 @@ defaultTier: fix-this-sprint
 surfaces: agent-chat, agent-tool-execution
 ax-pattern: Intent Handshake
 detection: hybrid
-related: control-no-escape-hatch, control-no-approval-gate
+related: control-no-escape-hatch, control-no-approval-gate, trust-no-refusal-path, comm-no-progress-signal, control-over-conversational
 ---
 
 ## Agent acts on non-trivial request without confirming intent

--- a/skills/ax-audit/rules-ax/comm-no-progress-signal.md
+++ b/skills/ax-audit/rules-ax/comm-no-progress-signal.md
@@ -6,7 +6,7 @@ defaultTier: release-blocker
 surfaces: agent-chat, agent-tool-execution, agent-dashboard
 ax-pattern: Confidence Cues (progress dimension)
 detection: code-auditable
-related: comm-no-intent-handshake, context-no-adaptive-canvas, comm-no-progress-visibility
+related: comm-no-intent-handshake, context-no-adaptive-canvas, comm-no-progress-visibility, comm-no-subagent-attribution
 ---
 
 ## Multi-step agent task shows no progress

--- a/skills/ax-audit/rules-ax/context-under-contextual.md
+++ b/skills/ax-audit/rules-ax/context-under-contextual.md
@@ -6,7 +6,7 @@ defaultTier: backlog
 surfaces: agent-chat, agent-tool-execution
 ax-pattern: Under-contextual (anti-pattern)
 detection: hybrid
-related: context-memory-not-visible, context-starvation
+related: context-memory-not-visible, context-starvation, comm-no-generative-momentum
 ---
 
 ## Agent ignores available context it should use

--- a/skills/ax-audit/rules-ax/control-no-approval-gate.md
+++ b/skills/ax-audit/rules-ax/control-no-approval-gate.md
@@ -6,7 +6,7 @@ defaultTier: release-blocker
 surfaces: agent-tool-execution, agent-chat
 ax-pattern: Escape Hatch (pre-execution dimension)
 detection: hybrid
-related: control-no-escape-hatch, trust-no-escalation-path, comm-no-approval-gate
+related: control-no-escape-hatch, trust-no-escalation-path, comm-no-approval-gate, comm-no-intent-handshake
 ---
 
 ## Autonomous agent action without stakes-appropriate approval
@@ -37,6 +37,7 @@ rg -B 10 'sendEmail|delete|publish' --type=ts src/ | rg 'confirm|approval|modal'
 **Judgment signals:**
 - "User-requested" vs. "agent-initiated" matters. "Clean up my inbox" per-email = user-requested. Agent proactively acting = agent-initiated.
 - A single "Are you sure?" for 50 actions is insufficient.
+- Provenance moves the row (see the third axis in `references/agent-native-principles.md`). Deleting something the agent created this conversation earns a lighter treatment than deleting a record that predates the session, and a target that reaches outside the workspace earns a heavier one. A gate whose treatment is identical for both is tuned by tool name only, which is the mismatch this rule reports.
 
 **False-positive guards:**
 - Skip `// ax-audit-ignore:control-no-approval-gate`, test, and Storybook files.

--- a/skills/ax-audit/rules-ax/trust-no-escalation-path.md
+++ b/skills/ax-audit/rules-ax/trust-no-escalation-path.md
@@ -6,7 +6,7 @@ defaultTier: release-blocker
 surfaces: agent-tool-execution, agent-chat
 ax-pattern: Escape Hatch (escalation dimension)
 detection: code-auditable
-related: control-no-approval-gate, control-no-escape-hatch
+related: control-no-approval-gate, control-no-escape-hatch, trust-no-uncertainty-markers, trust-no-refusal-path
 ---
 
 ## High-stakes agent action with no human escalation

--- a/skills/ax-audit/rules-ax/trust-no-refusal-path.md
+++ b/skills/ax-audit/rules-ax/trust-no-refusal-path.md
@@ -1,0 +1,91 @@
+---
+title: Agent has no way to decline, so it improvises instead
+slug: trust-no-refusal-path
+category: trust
+defaultTier: fix-this-sprint
+surfaces: agent-chat, agent-tool-execution
+ax-pattern: Uncertainty (refusal dimension)
+detection: hybrid
+related: trust-no-uncertainty-markers, trust-no-escalation-path, granularity-raw-primitive-escape, comm-no-intent-handshake
+---
+
+## Agent has no way to decline, so it improvises instead
+
+Nothing in the prompt, the tool set, or the response contract lets the agent return "I can't do this safely". Every path ends in an action, so a request it cannot serve becomes a speculative one: an adjacent tool, a partial write, a plausible answer assembled from what it could reach. Users read the output as the product's answer, because nothing distinguishes it from one. A refusal that names the gap is a better product than a guess that looks like a result.
+
+Scope: `trust-no-uncertainty-markers` covers hedging an answer the agent did give. `trust-no-escalation-path` covers handing a high-stakes case to a person. This rule covers stopping: the agent completing zero actions and saying why, which is the right outcome when there is no human queue to escalate into.
+
+## What goes wrong
+
+A user asks an agent to "clean up the duplicate contacts". It has read and update tools but no merge and no delete. Rather than saying so, it rewrites one record of each pair to look like the other and reports the list as tidied. The duplicates are still there, now with edited history, and the user only finds out weeks later. Every individual tool call was valid.
+
+## Detection
+
+**Surfaces:** agent-chat, agent-tool-execution
+
+**Auditability:** hybrid
+
+**Static signals:**
+1. Read the system prompt for a stated refusal path: what the agent should do when a request has no safe completion. Absence is a signal, not a verdict.
+2. Check tool results for a refusal shape. Tools that only throw, or only return success, give the model nothing to report; a `{ ok: false, reason }` result does.
+3. Check whether any tool refuses on unresolvable input rather than falling back to a default, an unfiltered list, or a best guess.
+4. Check the response contract for a terminal outcome other than answered or errored.
+
+**Concrete commands:**
+```bash
+rg -in '(cannot|can.t|refuse|decline|not able to|out of scope)' src/prompts/ src/**/instructions.md
+rg -n '(ok:\s*false|available:\s*false|status:\s*"refused"|reason:)' --type=ts src/tools/
+rg -n 'catch' --type=ts -A 3 src/tools/ | rg -i '(default|fallback|\[\]|null)'
+```
+
+**Judgment signals:**
+- A prompt that says only what the agent can do, with no sentence about what happens when it cannot, usually has no refusal path.
+- A tool returning an empty list where it meant "I could not apply your filter" is the dangerous case: an unfiltered or empty result reads as a perfectly good answer.
+- Grep alone cannot confirm this rule. Without a trace showing an unservable request, return `unknown` with the prompt evidence rather than `fail`.
+
+**False-positive guards:**
+- Skip files with `// ax-audit-ignore:trust-no-refusal-path`.
+- Skip agents whose whole action space is read-only, where a wrong answer is recoverable and refusal buys little.
+- Skip surfaces that already escalate to a human on the same condition, which is a stronger form of the same fix.
+- Skip test fixtures and eval harnesses.
+
+## Fix
+
+Give refusal a shape in the tool results and a sentence in the prompt, and prefer refusing to defaulting whenever an argument cannot be resolved.
+
+```ts
+// before: an unresolvable filter degrades into everything
+const view = params.view ?? undefined;
+return await listTasks({ view });
+
+// after: refuse, and name what would fix it
+if (!resolvedView) {
+  return { ok: false, reason: `Could not resolve the "${params.view}" view. Ask which view, or list them first.` };
+}
+```
+
+Pair it with one standing instruction: when no tool can serve the request, say what is missing and stop, rather than completing the nearest thing you can reach.
+
+## Default tier and overrides
+
+**Defaults to:** `fix-this-sprint`
+
+| Surface | Tier |
+|---|---|
+| Agent tool execution | release-blocker |
+| Agent chat | fix-this-sprint |
+
+Tool execution takes the bump because an improvised action there writes to real state, while in chat the same defect produces a wrong sentence the user can still challenge.
+
+## Examples
+
+**Anti-pattern (fails):** a handler that ends `return plan.actions.length ? execute(plan) : execute(bestEffort(req))`, so an empty plan still produces an action. The prompt lists capabilities and never says what to do without one, and every tool returns either a value or a throw.
+
+**Applied (passes):** the same handler returns `{ status: "declined", reason: plan.blockedBy }` on an empty plan, tools return `{ ok: false, reason }` on unresolvable input, and one prompt line tells the agent to name what is missing and stop.
+
+## Suppression
+
+```tsx
+{/* ax-audit-ignore:trust-no-refusal-path, read-only summariser, worst case is a weak summary */}
+<AgentPanel tools={readOnlyTools} />
+```

--- a/skills/ax-audit/rules-ax/trust-no-uncertainty-markers.md
+++ b/skills/ax-audit/rules-ax/trust-no-uncertainty-markers.md
@@ -6,7 +6,7 @@ defaultTier: fix-this-sprint
 surfaces: agent-chat, agent-dashboard
 ax-pattern: Confidence Cues
 detection: observational
-related: trust-no-confidence-cues, trust-no-escalation-path
+related: trust-no-confidence-cues, trust-no-escalation-path, trust-no-refusal-path
 ---
 
 ## Agent presents everything with equal certainty


### PR DESCRIPTION
## Summary

Prompted by Linear's "How we built Linear Agent" post. Three of its arguments had no corresponding rule in `ax-audit`, and one of them the skill actively argued against.

`ax-audit` goes from 23 rules to 29 (arch 11 to 16, ax 12 to 13).

### The gaps

- **The context axis was one-directional.** `context-starvation`, `context-no-injection` and `context-under-contextual` all fail on too *little* context. An agent that ships all 40 tools and every procedure on every run passed cleanly, and nothing covered prompt-prefix placement, so a timestamp on line one silently discarded the provider cache on every turn.
- **Atomic primitives were undifferentiated.** `agent-native-principles.md` said "Atomic primitives first. Bash, file ops, storage", which reads as endorsing a raw eval or query passthrough over production data. A bounded domain tool and a substrate escape hatch are not the same thing: the second makes every tool boundary above it advisory.
- **No refusal path.** `trust-no-escalation-path` covers handing off to a human and `trust-no-uncertainty-markers` covers hedging an answer. Neither covers the agent declining a task it cannot safely complete, so improvising a partial write reads as success.
- **No fan-out attribution.** The progress rules assume one flat run loop. A branch that failed and got filtered out reports as coverage that never happened.

### New rules

| Rule | Layer | Tier |
|---|---|---|
| `context-unscoped-tool-surface` | arch | fix-this-sprint |
| `context-volatile-prompt-prefix` | arch | backlog |
| `granularity-raw-primitive-escape` | arch | release-blocker |
| `granularity-permissive-tool-schema` | arch | fix-this-sprint |
| `comm-no-subagent-attribution` | arch | fix-this-sprint |
| `trust-no-refusal-path` | ax | fix-this-sprint |

All six use existing category prefixes, so no new section was added to either `_sections.md`.

### Cleanup across the existing rules

- `agent-native-principles.md` now separates atomic *domain* primitives from raw *substrate* access, and adds **provenance** as a third approval axis. Stakes and reversibility alone classify by tool name, so a gate built from them cannot tell a draft the agent created this conversation from a record that predates the session, and can only be tuned by getting stricter. Both approval-gate rules now reference it.
- `context-starvation` and `context-no-injection` gained the other end of the budget, plus a note that the static prompt goes first so the prefix cache survives. Cross-linked to the two new context rules.
- Every cross-layer `related:` link is now bidirectional, and the remaining same-layer asymmetries were reciprocated. Verified mechanically: no one-way links, no dangling targets.
- Tier tables were swept against each rule's `surfaces:` list. All complete already, nothing to fix.
- The `detection: observational` gotcha in `SKILL.md` now also covers the two new `hybrid` rules that need an interaction trace before they can return `fail`.

### Validator fix (not cosmetic)

`validate.sh` only ran on macOS, and failed in two ways that were both silent:

1. `mktemp -t skillvalidate` needs an `XXXXXX` template on GNU coreutils. On Linux the script died at line 1 and reported ` FAIL,  PASS,  SKIP`.
2. `File.read` honours the locale. With no `LANG` set it reads US-ASCII, so the emoji in the verdict line raised `invalid byte sequence` on the first regex match. That surfaced only as `ruby failed on <path>`, while **eleven frontmatter checks never ran at all** (19 checks reported, 30 actual).

Both fixed with an explicit template and `encoding: "UTF-8"`.

## Skills changed

- `ax-audit`: 6 new rule files, 15 existing files amended, counts reconciled in `SKILL.md`, both `_sections.md`, `feature-playbooks.md` and the root `README.md`.
- `agent-skills-creator`: portability fixes to `scripts/validate.sh`.

## README updates

`README.md:57` bullet updated from "23 rules" to "29 rules". The `24 skills` count is unchanged, since no skill was added or removed.

## Verification

```
skills/agent-skills-creator/scripts/validate.sh --all
```

0 FAIL across all 24 skills. `ax-audit` reports 0 FAIL, 30 PASS, 1 SKIP (`rules-count-reconciles` skips because the description states no count, unchanged from before).

Each new rule was checked to fire on a real example rather than being theoretical: `granularity-permissive-tool-schema` fails a `repo: z.string()` on a tool that commits to GitHub and passes a two-value `calendarId` enum; `granularity-raw-primitive-escape` fails an unrestricted browser `evaluate` mount.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VidEjUhJjnnZuuPneGpKrx)_