### PR TITLE
Add the context-errors review lens for agent-written diffs

### DIFF
--- a/skills/pr-reviewer/SKILL.md
+++ b/skills/pr-reviewer/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   findings report. Modes cover standard bugs, structural quality, AI slop, and
   security audit. Use when asked to run /pr-reviewer, "review my changes",
   "code review", "thermo-nuclear review", "structural review", "deslop this",
-  "clean up AI code", "security audit", "find vulnerabilities", or before
+  "clean up AI code", "security audit", "find vulnerabilities", "did this land
+  in the right place", or before
   commit, push, or handoff. For fixes use tidy; for PR creation use
   pr-creator; for CI or review comments use pr-babysitter; for frontend UX,
   accessibility, layout, state coverage, or rendered quality use ui-design
@@ -41,6 +42,7 @@ Pick one mode from the user's wording; load only its references:
 
 Conditional loads:
 
+- `references/context-errors.md` when the diff was agent-written, or when it adds a module, a system boundary, a guard, or a fallback. Covers the two mistakes that are invisible inside the diff: code that duplicates or bypasses something already in the repo, and code guarding a state this system never produces.
 - `references/security-checklist.md` for auth, input handling, external APIs, uploads, or environment config.
 - `references/performance-checklist.md` for fetching, rendering, images, dependencies, or bundle-affecting imports.
 - `agents/openai.yaml` only when a different-model CLI is installed and you are running the optional second-opinion pass below.
@@ -52,17 +54,18 @@ Review progress:
 - [ ] Dispatch mode and load references
 - [ ] Discover target
 - [ ] Gather context and baseline checks
-- [ ] Review: added lines, removed lines, call sites, shard if needed
+- [ ] Review: added lines, removed lines, call sites, outside the diff, shard if needed
 - [ ] Verdict each candidate: confirmed, plausible, or refuted
 - [ ] Report
 ```
 
 1. **Discover target.** Review staged/unstaged changes first; if clean, review the branch diff. For a PR, use the same criteria and the PR handoff format.
 2. **Gather context.** Capture intent. Load scoped `AGENTS.md` / `CLAUDE.md`; conventions there override this skill's defaults when they conflict, so a pattern they mandate is not a finding. Run documented lint, type-check, and tests where they exist; record baseline failures.
-3. **Review.** Apply the loaded rubric and high-signal criteria; shard large diffs. Three passes over the diff, because each finds what the others structurally cannot:
+3. **Review.** Apply the loaded rubric and high-signal criteria; shard large diffs. Four passes, because each finds what the others structurally cannot:
    - **Added lines.** Read every hunk, then the enclosing function. A bug on an unchanged line of a touched function is in scope: this diff re-exposed it.
    - **Removed lines.** For every line the diff deletes or replaces, name the invariant it enforced, then find where the new code re-establishes it. If you cannot, that is the finding: a removed guard, a dropped error path, a narrowed validation, a deleted test that covered a real case. Deletions read as progress and get skimmed, which is exactly why this pass earns its cost.
    - **Call sites.** For each changed function, grep its callers and check for a new precondition, a changed return shape, a new exception, or an ordering dependency. Then check its callees: does another change in the same diff make one of its own calls unsafe?
+   - **Outside the diff.** The three passes above judge the diff against itself, so a change that is wrong only relative to the codebase leaves no trace in any of them. For each new module, guard, or fallback, open what the diff did not: the directory's existing exports, the sibling implementations of the same class of behavior, and every writer of the value being guarded. A reimplementation of an existing helper, a change filed in the wrong system, and a fallback for a state nothing produces all read as clean code until you look at the file the diff never opened. `references/context-errors.md` carries the searches and the evidence each finding needs.
 
    Optional and skippable: where a different-model CLI is already installed (`codex exec`, `droid exec`, or equivalent), run it read-only with `agents/openai.yaml`'s `default_prompt` for a second opinion, then verdict its findings like your own. No such CLI is not a blocker; the review is complete without it.
 4. **Verdict.** Re-check exact lines and give every candidate one of three verdicts. Report confirmed and plausible; drop refuted.
@@ -84,6 +87,7 @@ Report only when certain:
 - Missing necessary tests: render-only checks for interactive behavior, or bug fixes without a failing repro test at the seam that failed (route, API, integration point, not a helper invented during the fix).
 - Test setup that requires helper tracing to understand assertions.
 - Scaffolding whose consumer is absent or unreachable: a test for a module that does not exist, a generated surface nothing imports, a CI check on a contract nothing emits. Cite the artifact's line and the search that found no consumer, and mark it plausible where the consumer could be generated at build time, reached by framework convention, or live outside this repo.
+- Guard, fallback, retry, or freshness mechanism covering a state the deployment does not produce: a value re-validated at every use that nothing writes after boot, invalidation for a consumer that tolerates the staleness anyway, degradation in a process a supervisor already restarts. Report it only with the writer set, the consumer's tolerance, or the restart policy named; without that the guard stays, because acting on this one deletes it. Distinct from a check the type system already rules out, which is a slop pattern rather than a finding here.
 - New lint, type-check, or test failures versus baseline.
 - Scoped instruction-file violation, with the rule quoted.
 - Retried or at-least-once write with no idempotency key or dedupe barrier, so a duplicate delivery applies twice.
@@ -108,7 +112,7 @@ Do not report style preferences, unrelated pre-existing issues, risks without a 
 
 ## Output
 
-Every finding carries `file:line`, a one-line impact, and a committable fix. A plausible finding adds one more line, `Plausible: <what would confirm it>`; a confirmed one omits it. Keep `Fix:` genuinely committable: it is what `tidy` applies, and a fix phrased as "consider refactoring this" cannot be applied by anyone.
+Every finding carries `file:line`, a one-line impact, and a committable fix. A plausible finding adds one more line, `Plausible: <what would confirm it>`; a confirmed one omits it. A finding that rests on something outside the diff (an existing module, a sibling change, the writers of a guarded value) adds a `Context:` line naming that artifact, so the reader can check the claim without re-running the search. Keep `Fix:` genuinely committable: it is what `tidy` applies, and a fix phrased as "consider refactoring this" cannot be applied by anyone.
 
 Default local report:
 
@@ -162,6 +166,8 @@ PR handoff format:
 - Line numbers counted off `git diff` hunk headers land in the report off by the hunk offset, and a reviewer who cannot find the cited line discards the rest of it too.
 - One broken helper reported once per call site reads as three problems and gets three separate patches, while the helper itself stays broken.
 - External-engine output is advisory. Re-validate everything against the actual diff.
+- Treating a second engine's agreement as corroboration. Both instances reviewed the same diff with the same missing context, so both approve the helper that already exists elsewhere and both accept the same unnecessary guard. Two agents agreeing proves they read the same lines; only the artifact outside the diff settles it.
+- A round that produces a new finding in the lines the previous round just changed. That is the loop generating work, not converging on a defect. Judge it across rounds: guards accumulating while severity falls, and each pass leaving the diff longer, means the next useful move is putting the simpler shape to the person who owns the system rather than reviewing again.
 - Skipping the baseline makes pre-existing failures look like regressions.
 - Refuting a real bug for being "speculative" costs more than a wrong finding does. The reader can dismiss a plausible finding in a sentence; nobody can dismiss the one you deleted.
 - Reading only the added lines. A diff that removes a guard shows up as green in the review and red in production.

--- a/skills/pr-reviewer/references/context-errors.md
+++ b/skills/pr-reviewer/references/context-errors.md
@@ -1,0 +1,127 @@
+# Context Errors
+
+The two mistakes a capable agent makes on a codebase it has not worked in: errors of ignorance and errors of paranoia. Both produce code that is competent, self-consistent, and locally defensible, which is exactly why a line-by-line pass over the diff approves them.
+
+Every other rubric here judges the diff against itself. This one judges the diff against the system it landed in, so every finding rests on an artifact outside the changed lines: an existing module, a sibling implementation, a writer set, a consumer's tolerance. A finding without that artifact is a guess and reads as one.
+
+## Contents
+
+- Errors of ignorance
+- Errors of paranoia
+- Evidence bar
+- Where review loops fail
+- Reporting
+
+## Errors of ignorance
+
+The code is right and the context is wrong. Nothing inside the diff is broken, so the passes over added lines, removed lines, and call sites cannot reach these. Each check below names the search that produces its evidence; run the search before writing the finding.
+
+### 1. Reimplemented module
+
+New code whose behavior something in this repo already provides.
+
+**Search:** the changed file's own directory, the nearest shared, lib, or utils directory, and the package's public exports. Grep for the distinctive verb or noun in the new function's name, then for the shape of what it returns.
+
+**Evidence:** the existing function, its path, and one live call site proving it is the current path rather than a dead one.
+
+### 2. Wrong home
+
+The change works, and it landed outside the system that owns this class of behavior. The usual shape: validation added in a route handler where a validator layer exists, a permission check inline where a policy module exists, a formatting rule in a component where a shared formatter exists.
+
+**Search:** find where the last two or three changes of the same class landed. `git log -S` on a distinctive symbol, or grep for the sibling cases the feature already has.
+
+**Evidence:** the sibling. Two siblings living somewhere else make the third one's location the finding.
+
+### 3. Convention divergence
+
+Naming, error handling, data access, or module boundaries that differ from the files around them. The standard is what the neighbors do, not what is idiomatic in the language. A scoped `AGENTS.md` or `CLAUDE.md` rule outranks both.
+
+**Evidence:** two or more sibling files doing it the other way. One neighbor is a coincidence, not a convention.
+
+### 4. Duplicate concept under a new name
+
+One domain rule given a second type, enum, status set, or constant. Both are correct today, and the rule now has two owners, so the next change to it lands in one of them.
+
+**Evidence:** the existing definition and the value that appears in both.
+
+### 5. Unowned surface
+
+A config key, environment variable, feature flag, migration, or route added without the registration path the existing ones take: a registry, a schema, a typed config object, a deploy manifest, a docs table. The diff works locally and the surface is invisible to whatever was supposed to know about it.
+
+**Evidence:** an existing member of the same surface, and the file where it is registered.
+
+**A search returning nothing is not evidence here.** For dead code the risk is calling something dead when a dynamic import reaches it; for ignorance the risk runs the other way, and an empty grep means the search was wrong at least as often as it means the module is absent. Widen the search or drop the finding.
+
+## Errors of paranoia
+
+Code that is correct, handles a state cleanly, and exists for a state this system does not produce. Distinct from the defensive-excess and unnecessary-error-handling entries in `ai-slop-patterns.md`, which fire when the type system already rules the state out. These fire when the type allows the state and the deployment never reaches it, so the evidence is never in the type signature.
+
+### 1. Redundant validation of a settled value
+
+A value set once from config, a constant, or a boot-time argument, re-validated at every use.
+
+**Evidence:** the writer set. Grep every assignment. Nothing writing it after startup means one check at the boundary is the whole requirement.
+
+### 2. Freshness engineering past the consumer's tolerance
+
+Invalidation, subscriptions, or polling added so a value is never stale, where the consumer tolerates the staleness the simpler path already gives.
+
+**Evidence:** the consumer and the tolerance it actually has: a render the user cannot observe inside a second, a report already batched hourly, a check re-run on the next request anyway.
+
+### 3. Graceful degradation where crashing is correct
+
+Fallbacks, default return values, and swallowed exceptions in a process that is restarted on failure (a CLI, a job, a pod, a queue consumer, a request handler) or where the degraded output is worse than none. The failure was loud and fixable; it is now a quiet wrong answer with no stack trace.
+
+**Evidence:** the supervisor or retry that already handles the crash, or the caller that cannot distinguish the fallback value from a real one.
+
+### 4. Rollback machinery for a step that does not need it
+
+Compensation logic wrapped around an operation that is idempotent, transactional, or has no external effect to undo.
+
+**Evidence:** the transaction boundary or the idempotency key that already makes the step safe to repeat.
+
+### 5. Concurrency defense on a single-writer path
+
+Locks, mutexes, version columns, or optimistic-concurrency retries on a path with one writer.
+
+**Evidence:** every caller, and the deployment shape (single worker, serialized queue, per-key partition) that keeps them from overlapping.
+
+## Evidence bar
+
+The asymmetry inverts here. For a correctness finding, the cost of being wrong is a sentence the reviewer spends dismissing it, so plausible is worth reporting. Acting on a paranoia finding deletes a guard, and the cost of being wrong is a bug. So the two halves of this file have different defaults.
+
+| Finding | Evidence required | Default without it |
+|---------|-------------------|--------------------|
+| Reimplemented module | Existing function, path, live call site | Drop it |
+| Wrong home | A sibling change of the same class, and where it landed | Report as plausible |
+| Convention divergence | Two sibling files doing it the other way | Drop it |
+| Duplicate concept | The existing definition | Drop it |
+| Unowned surface | An existing member and its registration site | Report as plausible |
+| Any paranoia finding | The named reason this system never reaches the state | The guard stays |
+
+## Where review loops fail
+
+- **A second model shares the failure mode, not just the training data.** Two agents reviewing the same diff have the same missing context, so both approve the reimplementation neither one opened and both accept the same guard. Agreement between them on an ignorance or paranoia call corroborates nothing; only the artifact does.
+- **Watch the sequence, not the round.** A loop is converging when findings resolve. It is generating work when findings move rather than close, when the guard count climbs while the reported severity falls, and when each round leaves the diff longer than it found it. Judge that across rounds; no single round looks wrong.
+- **The simpler shape does not surface on its own.** "Delete this and accept the risk" is a judgement about the system, not a defect in the diff, so a pass built to find defects will never propose it. Where a paranoia finding survives a round of fixes, or a fix keeps returning in a new form, putting the smaller shape to whoever owns the system, with the risk named in one line, is usually worth more than another round.
+
+## Reporting
+
+Use `SKILL.md`'s finding format with one added line, `Context:`, naming the artifact the finding rests on.
+
+```markdown
+- [major] `src/api/orders.ts:118` Order status re-defined instead of using the shared enum
+  Why: `OrderStatus` in `src/domain/order.ts:12` already owns these five values, so the rule now has two owners and the next status change lands in one of them.
+  Fix: Import `OrderStatus` and delete the local union.
+  Context: `src/domain/order.ts:12`, imported by `src/domain/order-state.ts:8` and three other call sites.
+
+- [minor] `src/workers/sync.ts:64` Retry wrapper around an already-idempotent write
+  Why: The write is keyed by `syncId` and the worker is restarted by the supervisor on failure, so the wrapper adds a second retry policy that hides which one fired.
+  Fix: Delete the wrapper and let the write fail.
+  Context: idempotency key set at `src/workers/sync.ts:41`; restart policy in `deploy/worker.yaml:22`.
+```
+
+Severity:
+
+- An ignorance finding is major when it creates a second owner for a rule or puts logic where the next change will not look for it. It is minor when the effect is local style.
+- A paranoia finding does not belong under `Must fix before push` on its own. It is code to delete, not a defect, and shipping it costs lines rather than correctness. It goes under `Should fix soon` unless the guard itself introduces a bug.

--- a/skills/tidy/SKILL.md
+++ b/skills/tidy/SKILL.md
@@ -76,7 +76,7 @@ The return format for each angle: one finding per bullet as `file:line`, issue, 
 Take each block of new code down this ladder and stop at the first rung that holds. The rung it stops on is the finding: everything below it is code that did not need to be written.
 
 1. **Does it need to exist at all?** Nothing calls it, nothing needs it yet, or the requirement it serves is speculative. Delete it.
-2. **Is it already in this codebase?** Search utility directories, shared modules, and the files adjacent to the changed ones. Name the existing function to use instead. Near-duplicate blocks inside the diff count too: two copies of the same logic with one value changed want one function with a parameter.
+2. **Is it already in this codebase?** Search utility directories, shared modules, and the files adjacent to the changed ones. Name the existing function to use instead, with its path and one live call site: a helper that exists but nothing calls is a dead path, and swapping onto it trades new code for a worse kind of new code. Near-duplicate blocks inside the diff count too: two copies of the same logic with one value changed want one function with a parameter.
 3. **Does the stdlib do it?** Hand-rolled string manipulation, date maths, path handling, ad-hoc type guards. Name the stdlib function.
 4. **Does a native platform feature cover it?** `<input type="date">` over a picker lib, CSS over JS, `Intl` over a formatting lib, a DB constraint over an app-level check.
 5. **Does an already-installed dependency solve it?** Check `package.json` before accepting anything new. Flag any dependency this diff adds for something the rungs above already cover.
@@ -120,14 +120,15 @@ Lint already catches unused imports, unreachable code, and hooks called conditio
 
 ### Angle 4: Altitude
 
-One question: is each change made at the right depth, or bolted on above it? The signal is a special case layered onto shared infrastructure. When a fix reads as "except for this case", the mechanism underneath is usually the thing that should have changed.
+One question: is each change made at the right place, or bolted on above the mechanism (items 1 to 4) or outside the system that owns it (item 5)? The signal for the first four is a special case layered onto shared infrastructure. When a fix reads as "except for this case", the mechanism underneath is usually the thing that should have changed.
 
 1. **Special case on a shared path**: a branch keyed to one caller, route, tenant, feature flag, or file type added inside code that serves all of them. Name the general rule the branch is an instance of, and whether the shared mechanism can express it
 2. **Fix at the call site instead of the source**: the same guard, coercion, or normalisation added at one caller when the function it calls could return the right shape for every caller. Grep every caller of the function the diff touches. One guard inside the shared function is a smaller diff than one per caller, and fixing only the path the ticket named leaves the sibling callers broken
 3. **Symptom fix**: a value corrected after the fact (clamping, re-sorting, patching a field back in) rather than produced correctly. Trace back to where it was built wrong
 4. **Fix that only holds for the reported input**: a condition tuned to the example in the ticket. Ask what the neighbouring input does
+5. **Wrong home**: the change works and landed outside the system that owns this class of behaviour. Validation in a route handler where a validator layer exists, a permission check inline where a policy module exists, a formatting rule in a component where a shared formatter exists. Find where the last two or three changes of the same class landed (`git log -S` on a distinctive symbol, or grep the sibling cases) and name the sibling. Two siblings living somewhere else make the third one's location the finding; one is a coincidence
 
-Altitude findings are the ones most worth raising and least worth forcing. Where lifting the fix means redesigning the shared mechanism, that is a summary note for the user, not an edit this pass makes. Apply it only when the deeper fix is smaller than the special case it replaces.
+Altitude findings are the ones most worth raising and least worth forcing. Where lifting the fix means redesigning the shared mechanism, that is a summary note for the user, not an edit this pass makes. Apply it only when the deeper fix is smaller than the special case it replaces. A wrong-home finding follows the same rule: move the change when the owning system already has the entry point for it, and note it for the user when it needs a new one.
 
 ### Angle 5: Test discipline
 
@@ -153,6 +154,7 @@ Scope rules:
 
 - Only edit files inside the diff. Reading an adjacent file to understand a pattern is fine; rewriting it is not.
 - No new abstractions, no architecture refactors, no fixes to pre-existing issues outside the diff. An altitude finding that needs the shared mechanism redesigned goes in the summary, not the working tree.
+- Deleting a guard is the one simplification that can introduce a bug, so it carries a higher bar than the rest. Remove a check, fallback, retry, or lock only after naming why this system never reaches the state it covers: every writer of the value, the consumer's real staleness tolerance, the supervisor that already restarts on failure, the single writer on the path. Where the reason cannot be named, the guard stays and the finding goes under "For you to decide" with the state spelled out. This is the inverse of every other angle, where the smaller diff wins ties.
 - Tests are never silently written: proposed missing tests are surfaced in the summary with the one-sentence failure each prevents, for the user to decide on. Useless tests added in this diff (Angle 5, category 4) get deleted like any other quality fix. Stale assertions in existing tests covering changed code do get fixed.
 
 ## Phase 4: Verify and report
@@ -191,6 +193,8 @@ Scope rules:
 - Rewriting a shared mechanism because Angle 4 found a special case: the altitude finding was right and the fix is a separate PR. This pass reports it and moves on.
 - Narrowing the sweep because a review already ran. The two look for different things, so a skipped angle is a real loss and the saving is imaginary. Run all five; dedupe at Phase 3.
 - Repeating a report's finding back in different words as if it were new. That is a dedupe failure, not a coverage win. Where an angle rediscovers something the report confirmed, it is one finding.
+- Deleting a guard because it looked paranoid, without grepping the writers first. Excess defence and necessary defence are the same code; only the system tells them apart, and this pass edits the working tree, so a wrong call here ships a bug rather than a noisy report.
+- A fix that draws a new finding in the lines the previous round just changed. Two rounds bouncing off each other converge on more code, not less, because a pass built to find defects never proposes deleting one. When the same spot keeps producing findings, stop editing it and put the simpler shape in "For you to decide" with the risk named.
 - Quietly not applying a confirmed review finding because you disagree with it. The user read that report and is expecting those lines to change. Apply it, or say plainly that you did not and why.
 
 ## Related skills


### PR DESCRIPTION
## Summary

Turns the failure modes from Sean Goedecke's "You have to beat the models at something" into review guidance.

His argument: frontier coding agents no longer produce hallucinations or off-by-one errors. They produce two other classes of mistake, both structurally hard for a model to catch in itself.

- **Errors of ignorance**: reimplementing a module that already exists, filing the change in a system that does not own the behavior, diverging from local convention. The code is competent and self-consistent, and wrong only relative to context outside the diff.
- **Errors of paranoia**: re-validating a value set once from config at boot, engineering freshness past what the consumer tolerates, degrading gracefully in a process that should crash and restart.

`ai-slop-patterns.md` already covers the paranoia patterns visible inside the diff (a guard the type system rules out). Nothing covered the ones that need the system to disprove. And every pass in `pr-reviewer` judged the diff against itself, so none of them could reach an error of ignorance: nothing in the diff is wrong.

## Skills changed

**`pr-reviewer`** (new reference plus edits)

- New `references/context-errors.md`: five ignorance checks and five paranoia checks, each with the search that produces its evidence; an evidence-bar table giving the default when the evidence is absent; a section on where review loops fail; and the `Context:` reporting format with worked findings.
- A fourth review pass, **Outside the diff**, with the three existing passes' blind spot stated plainly.
- One high-signal criterion: a guard, fallback, retry, or freshness mechanism covering a state the deployment does not produce, reportable only with the writer set, consumer tolerance, or restart policy named.
- A `Context:` line in the output format, so a finding resting on evidence outside the diff names the artifact.
- Two gotchas: a second engine's agreement is not corroboration when both instances share the missing context, and a round that draws a new finding in the lines the last round changed is generating work rather than converging.
- One added trigger phrase in the description.

**`tidy`** (edits)

- Angle 4 gains a fifth item, wrong home, with the sibling-landing search. The angle's framing question now covers place as well as depth.
- Angle 1's second rung requires the existing function's path and a live call site, since swapping onto a dead helper is not reuse.
- A Phase 3 scope rule: guard removal is the one simplification that can introduce a bug, so it needs the reason the system never reaches the state, or the guard stays and the finding goes to the user.
- Two gotchas covering the same ground for a pass that edits the working tree.

The paranoia asymmetry is the point worth reviewing: it runs opposite to the correctness rubric. `pr-reviewer` says refuting a real bug costs more than a wrong finding, because a reader dismisses a plausible finding in a sentence. Acting on a wrong paranoia finding deletes a real guard, so that default flips.

Escalation guidance is descriptive rather than an absolute rule, by request.

## README

No change. No skill is added or removed, so the count and the category bullets stay as they are.

## Validation

`skills/agent-skills-creator/scripts/validate.sh` passes on both changed skills and on `--all` (25 skills, 0 FAIL).

Two pre-existing environment quirks needed working around in this container, neither touched in the diff: the script's `mktemp -t skillvalidate` is the BSD form, which GNU coreutils rejects for having no X's in the template, and Ruby defaults to US-ASCII without a UTF-8 locale, so `frontmatter-parses` fails on the twelve `SKILL.md` files containing a non-ASCII byte. Both are worth a separate fix if the validator is meant to run on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDpXk19oYrnYr5r5KyztZF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDpXk19oYrnYr5r5KyztZF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skill markdown; no application runtime, auth, or data paths affected.
> 
> **Overview**
> Adds a **context-errors** review lens so reviews judge agent-written changes against the repo, not only the diff itself.
> 
> **`pr-reviewer`** gets a new `references/context-errors.md` (ignorance vs paranoia mistakes, search/evidence rules, and **`Context:`** reporting). The workflow adds a fourth pass **Outside the diff**, conditionally loads that reference for agent-written or boundary/guard changes, extends high-signal rules for guards/fallbacks that cover unreachable deployment states, and adds gotchas about multi-agent agreement and non-converging review loops. The skill description gains the trigger *"did this land in the right place"*.
> 
> **`tidy`** aligns cleanup with the same ideas: Angle 1 reuse requires a **live call site** for existing helpers; Angle 4 adds **wrong home**; Phase 3 treats **guard deletion** as higher-risk (evidence or *For you to decide*); plus matching gotchas because tidy edits the tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a5b54a1ce87558d5f8e48f4d288d8bd0ee76777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->