### PR TITLE
Point class-merging guidance at the cn package

### DIFF
--- a/skills/scaffold-nextjs/references/app-setup.md
+++ b/skills/scaffold-nextjs/references/app-setup.md
@@ -188,25 +188,13 @@ Order matters: `registry add` must run before any `add @blode/...` call, or the 
 
 Creates:
 - `components.json`: shadcn config, the Blode registry mapping, and the icon library
-- `lib/utils.ts`: `cn()` helper (clsx + tailwind-merge, replaced below)
+- `lib/utils.ts`: `cn()` helper, re-exported from the [`cn`](https://github.com/shadcn-ui/cn) package
 - `components/ui/button.tsx`: button from the Blode registry
 - CSS variable updates in `app/globals.css`
 
 Icons: use `blode-icons-react` for all icon imports. If any generated file still imports `lucide-react`, replace the import paths with `blode-icons-react`. `lucide-react` is not a dependency of this scaffold; if it appears in `package.json`, remove it.
 
-Class merging: `shadcn init` still writes the `twMerge(clsx(...))` wrapper. Swap it for [`cn`](https://github.com/shadcn-ui/cn), which does the conditional joining and the Tailwind conflict resolution in one function and is what the Blode registry's own `utils` item ships:
-
-```bash
-npm install cn
-npm uninstall clsx tailwind-merge
-```
-
-```ts
-// lib/utils.ts
-export { cn } from "cn";
-```
-
-Leave `class-variance-authority` alone; it is a separate concern and still needed for variants.
+Class merging goes through `cn`, which does the conditional joining and the Tailwind conflict resolution in one function. Do not add `clsx` or `tailwind-merge`. `class-variance-authority` is a separate concern and is still what defines variants.
 
 ## Phase 4: Install Agentation
 

--- a/skills/scaffold-nextjs/references/app-setup.md
+++ b/skills/scaffold-nextjs/references/app-setup.md
@@ -188,11 +188,25 @@ Order matters: `registry add` must run before any `add @blode/...` call, or the 
 
 Creates:
 - `components.json`: shadcn config, the Blode registry mapping, and the icon library
-- `lib/utils.ts`: `cn()` helper (clsx + tailwind-merge)
+- `lib/utils.ts`: `cn()` helper (clsx + tailwind-merge, replaced below)
 - `components/ui/button.tsx`: button from the Blode registry
 - CSS variable updates in `app/globals.css`
 
 Icons: use `blode-icons-react` for all icon imports. If any generated file still imports `lucide-react`, replace the import paths with `blode-icons-react`. `lucide-react` is not a dependency of this scaffold; if it appears in `package.json`, remove it.
+
+Class merging: `shadcn init` still writes the `twMerge(clsx(...))` wrapper. Swap it for [`cn`](https://github.com/shadcn-ui/cn), which does the conditional joining and the Tailwind conflict resolution in one function and is what the Blode registry's own `utils` item ships:
+
+```bash
+npm install cn
+npm uninstall clsx tailwind-merge
+```
+
+```ts
+// lib/utils.ts
+export { cn } from "cn";
+```
+
+Leave `class-variance-authority` alone; it is a separate concern and still needed for variants.
 
 ## Phase 4: Install Agentation
 

--- a/skills/ui-design/componentize.md
+++ b/skills/ui-design/componentize.md
@@ -20,7 +20,7 @@ Use when componentizing, extracting, or organizing UI code into reusable compone
 
 - Break designs into small, focused components instead of one large component: extract repeated patterns, logical sections, and self-contained UI blocks
 - Never bake margins into components: apply margins at the call site; every component must accept a `class` attribute and merge it with the classes on the component's top-level element
-- Use `clsx` or similar to merge classes in client-side components
+- Use the project's existing class-merging helper (`cn` in a shadcn/Tailwind project, from the [`cn`](https://github.com/shadcn-ui/cn) package) to merge classes in client-side components
 - Always extract form controls into reusable components organized by HTML element: one `Input` for all `<input>` types (text, email, password, etc.), one `Select` for `<select>`, one `Textarea` for `<textarea>`; never type-specific components like `EmailInput` or `PasswordInput`; check the project for existing ones first
 - When two or more elements share the same structure and styling but differ only in props (labels, placeholders, types): extract them into a single component parameterized by those differences
 - After extracting, scan components for duplicated patterns and extract shared elements into reusable components: e.g. repeated section container/max-width/padding wrappers, heading group structures (eyebrow + heading + subheading), card shells, button styles


### PR DESCRIPTION
Follows the Blode UI migration to [`cn`](https://github.com/shadcn-ui/cn), which replaces the `clsx` + `tailwind-merge` wrapper with a single zero-dependency function.

## Skills changed

- `scaffold-nextjs` (`references/app-setup.md`): the "Creates" bullet names `cn` as the helper the scaffold gets, and a short note after the icons paragraph says class merging goes through it, that `clsx` and `tailwind-merge` should not be added, and that `class-variance-authority` still defines variants.
- `ui-design` (`componentize.md`): the class-merging rule pointed at `clsx`; it now points at the project's existing helper, naming `cn` for shadcn/Tailwind projects.

No new skills, so no README count or bullet changes. `skills/agent-skills-creator/scripts/validate.sh --all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsXMGT3C7grwpjmzDb2Lo7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill reference updates; no runtime code, config, or scaffold scripts changed.
> 
> **Overview**
> Agent skills docs now match the Blode UI move to the standalone [`cn`](https://github.com/shadcn-ui/cn) helper instead of a local `clsx` + `tailwind-merge` wrapper.
> 
> **`scaffold-nextjs`** (`app-setup.md`): the Phase 3 “Creates” bullet describes `lib/utils.ts` as re-exporting `cn` from that package, and a new note states that all class merging goes through `cn`, that **`clsx` and `tailwind-merge` must not be added**, and that **`class-variance-authority` still owns variants**.
> 
> **`ui-design`** (`componentize.md`): the class-merge rule no longer says “use `clsx`”; it tells authors to use the project helper—**`cn` on shadcn/Tailwind stacks**—with a link to the same package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1e9c46c97a6e990bb5f8503c401f966089506c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->