### PR TITLE
Verify the canonical published content URL

### DIFF
--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           for attempt in $(seq 1 60); do
             served=$(curl --fail --silent --show-error --max-time 20 \
-              "https://blode.co/agent-skills/llms.txt?revision=$EXPECTED_SHA&attempt=$attempt" \
+              "https://blode.co/agent-skills/llms.txt" \
               | sed -nE 's/.*\(synced at ([0-9a-f]{40})\).*/\1/p' | head -1) || served=""
             if [[ "$served" =~ ^[0-9a-f]{40}$ ]]; then
               if [ "$served" = "$EXPECTED_SHA" ]; then


### PR DESCRIPTION
The publication check used a unique query string, which could verify fresh content while the plain llms.txt URL remained cached at an older revision. Verify the canonical URL so stale content cannot produce a successful publication check.

Confirmed the discrepancy against production and removed only the cache-busting query. The exact-SHA and descendant checks are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to which URL is polled; deploy hook and revision logic are unchanged.
> 
> **Overview**
> Publication verification in **Rebuild agent-skills-web** now polls **`https://blode.co/agent-skills/llms.txt`** instead of the same path with `revision` and `attempt` query parameters.
> 
> That closes a gap where the cache-busted URL could reflect the new revision while the canonical file users hit stayed on an older sync SHA. The loop still parses the embedded `(synced at …)` hash and applies the same exact-SHA and descendant acceptance rules; only the fetch URL changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f2a7d9d7bc459bdfdab18881dd30fd4f8984a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->