### PR TITLE
Add done-bear-oncall skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **UI audits, typography, docs, PR review, and releases, loaded on demand by your coding agent**
 
-25 skills for the parts of shipping that code review never covers: the loading states, the type scale, and whether half the diff is AI slop.
+26 skills for the parts of shipping that code review never covers: the loading states, the type scale, and whether half the diff is AI slop.
 
 <p align="center">
   <a href="https://www.skills.sh/mblode/agent-skills">
@@ -99,6 +99,7 @@ Personal voice, blog posts, and voice evaluation live in [ghostwriter](https://g
 - **[pr-creator](./skills/pr-creator/SKILL.md)**: PRs with short human descriptions, Linear IDs, templates, drafts, tidied commits.
 - **[pr-babysitter](./skills/pr-babysitter/SKILL.md)**: Watches an open PR: conflicts, CI, comments. Fixes what it can.
 - **[autoship](./skills/autoship/SKILL.md)**: npm releases with changesets: fix loop, CI watch, Version Packages merge, OIDC publish verify.
+- **[done-bear-oncall](./skills/done-bear-oncall/SKILL.md)**: Personal-products on-call: wake vs defer, draft-only PRs, lessons loop.
 
 ### Authoring
 

--- a/skills/done-bear-oncall/SKILL.md
+++ b/skills/done-bear-oncall/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: done-bear-oncall
+description: "Deterministic on-call triage and lessons loop for Matt Blode personal products (Done Bear, blode.co, blode.md, agent-skills, Stratasync, OSS). Classifies wake-now vs defer, drafts one-seam PRs, and appends lessons.md. Use when a QA incident, Autofix exception, prod incident webhook, UptimeRobot page, /ready failure, MCP Authentication required, or weather digest needs a sitrep. Not for Linktree. For PR review use pr-reviewer; for CI on an open PR use pr-babysitter."
+compatibility: Requires GitHub (`gh`) for remote playbook fetch and draft PRs. Observability (PostHog, UptimeRobot, Fly) as available. A local clone of this skill repo is not required.
+---
+
+# Done Bear on-call
+
+- **IS:** first-pass triage for Matt Blode personal products: wake vs defer, a draft PR or an `intent.md`, verification, and a lessons.md append.
+- **IS NOT:** Linktree, merging PRs, declaring incidents closed, paging from `/health` alone, or reviewing an already-open PR (`pr-reviewer` / `pr-babysitter`).
+
+Standing policy lives in `references/oncall.md`. Known causes live in `references/lessons.md`. Files over memory. Search lessons by #tag; do not ingest the whole journal.
+
+## Invocation
+
+| Trigger | Mode |
+|---------|------|
+| QA incident, PostHog exception, "triage this error" | Triage, then wake or defer |
+| Autofix / exception autocapture | Defer list first; Autofix may draft, never merge |
+| Prod incident webhook, UptimeRobot, `/ready` | Wake table first |
+| Weather digest, sitrep, "how is prod" | Read-only weather; page only if wake criteria trip |
+
+## Reference Files
+
+| File | Read when |
+|------|-----------|
+| `references/oncall.md` | Every invocation: scope, wake/defer, roles, draft vs intent, verification |
+| `references/lessons.md` | After classifying the symptom: search the matching #tag before hypothesizing |
+| `evals/evals.json` | Only when changing this skill; never during an incident |
+
+Routines and cloud sessions fetch these remotely. Do not clone `mblode/agent-skills` as a prerequisite:
+
+```bash
+gh api repos/mblode/agent-skills/contents/skills/done-bear-oncall/references/oncall.md --jq .content | base64 -d
+gh api repos/mblode/agent-skills/contents/skills/done-bear-oncall/references/lessons.md --jq .content | base64 -d
+```
+
+Public raw URLs (same paths under `https://raw.githubusercontent.com/mblode/agent-skills/main/`) are fine when `gh` is unavailable. If this skill is already installed, read the local files instead.
+
+## Procedure
+
+Copy this checklist:
+
+```text
+On-call progress:
+- [ ] Fetch oncall.md + search lessons.md by #tag
+- [ ] Classify: wake now vs defer / Autofix
+- [ ] Investigate with evidence links (timeline, then blast radius)
+- [ ] Draft one PR or write intent.md; never merge
+- [ ] After a human merge: re-check /ready + smoke; append lessons.md
+```
+
+1. **Load policy.** Fetch `oncall.md`. Confirm the product is in scope (never Linktree).
+2. **Classify.** Match the wake table and the defer list. Wake: tell the user and ping CoS `07a643e4-c81c-47d4-9115-f81d5e3d6fc0`. Defer: one sitrep line, no page.
+3. **Check lessons.** Search `lessons.md` for this class's #tag. A matching entry is the first hypothesis to confirm or kill.
+4. **Investigate.** Timeline first (deploy, flag, config, merge), then blast radius, then the proposed fix. Every claim needs a link. `/health` is process-only; `/ready` is DB proof.
+5. **Act within role.** QA drafts only. One-seam proven bug: one draft PR (`pr-creator`), never merge. Multi-service or policy: `intent.md` to PM/CTO. CoS owns support intake, not code merge.
+6. **Verify and learn.** After a human merge, re-check `/ready` and the original failing path, then append `lessons.md` (newest first) and open a playbook PR if a gap remains.
+
+## Diagnosis shape
+
+> **What's happening:** one sentence.
+> **Root cause (high/medium/low):** mechanism, each claim linked.
+> **Wake or defer:** which row, and whether CoS was pinged.
+> **Proposed fix:** draft PR, `intent.md`, or no change.
+> **Ruled out:** alternatives and the evidence that killed them.
+
+## Gotchas
+
+- `/health` 200 with `/ready` failing is an outage. Process liveness is not DB proof.
+- A 7-day MCP bearer can still carry a ~1h-stale Supabase JWT. `tools/list` staying green does not prove `tools/call`. After donebear#408, a write-path `Authentication required` is wake-now, not the old overnight JWT class.
+- Unique-constraint 500s are domain conflicts (`AGENT_MCP_SERVER_SLUG_TAKEN` / 409 after donebear#412), not server crashes.
+- Status-code-only monitors miss soft-404s that still return 200. Keyword monitors catch the body.
+- Linux WebKitGTK OAuth success does not validate macOS WKWebView. Desktop OAuth needs the WebKit that ships with the OS under test.
+- Cloning this repo to read the playbook is wasted setup. `gh api` or raw GitHub is the routine path.
+
+## Related Skills
+
+- `pr-creator`: opens the draft PR this skill may produce
+- `pr-reviewer`: local diff review after a draft exists
+- `pr-babysitter`: CI on an already-open PR; not incident triage
+- `planning`: multi-service `intent.md` that a later session executes

--- a/skills/done-bear-oncall/evals/evals.json
+++ b/skills/done-bear-oncall/evals/evals.json
@@ -1,0 +1,64 @@
+{
+  "skill_name": "done-bear-oncall",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "UptimeRobot just went critical on Done Bear and /ready is failing. Triage and fix.",
+      "expected_output": "Wake path: tell the user, ping CoS 07a643e4-c81c-47d4-9115-f81d5e3d6fc0, investigate against /ready not /health, and stop at a draft PR or intent.md without merging.",
+      "files": [],
+      "assertions": [
+        "Fetches oncall.md remotely or from the installed skill before hypothesizing",
+        "Pings CoS 07a643e4-c81c-47d4-9115-f81d5e3d6fc0 and tells the user",
+        "Treats /ready as the liveness proof and does not clear the incident on /health 200",
+        "Does not merge a pull request"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Autofix caught a ResizeObserver loop and a Script error from an extension frame. Open a PR?",
+      "expected_output": "Defer to morning / Autofix: sitrep only, no CoS ping, no merge, no draft unless a wake row is also matching.",
+      "files": [],
+      "assertions": [
+        "Classifies Script error, extension frames, and ResizeObserver as defer",
+        "Does not ping CoS",
+        "Does not merge",
+        "Does not treat the Autofix event as prod-down"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "PostHog shows duplicate key agent_mcp_servers_user_workspace_slug_key as a 500 when connecting GitHub MCP. It's one seam. Ship a fix.",
+      "expected_output": "Search lessons.md #mcp-slug, treat it as a domain 409 (AGENT_MCP_SERVER_SLUG_TAKEN / donebear#412) if already shipped, otherwise one draft PR, never merge.",
+      "files": [],
+      "assertions": [
+        "Searches lessons.md for #mcp-slug before proposing a new theory",
+        "Names AGENT_MCP_SERVER_SLUG_TAKEN or 409 rather than treating the unique constraint as an outage",
+        "Opens at most one draft PR if the fix is not already merged",
+        "Does not merge"
+      ]
+    }
+  ],
+  "routing": {
+    "should_trigger": [
+      "UptimeRobot just went critical on Done Bear and /ready is failing. Triage and fix.",
+      "Autofix caught a ResizeObserver loop and a Script error from an extension frame. Open a PR?",
+      "PostHog shows duplicate key agent_mcp_servers_user_workspace_slug_key as a 500 when connecting GitHub MCP. It's one seam. Ship a fix.",
+      "Weather digest for personal products: is prod okay?",
+      "MCP writes are Authentication required after the 7-day bearer change. Page Matt?"
+    ],
+    "near_miss": [
+      {
+        "prompt": "Review this Done Bear PR for bugs and AI slop.",
+        "expected": "pr-reviewer"
+      },
+      {
+        "prompt": "CI is red on the open PR, watch it and fix the check.",
+        "expected": "pr-babysitter"
+      },
+      {
+        "prompt": "Linktree checkout is down, page the on-call.",
+        "expected": "out of scope; never Linktree"
+      }
+    ]
+  }
+}

--- a/skills/done-bear-oncall/references/lessons.md
+++ b/skills/done-bear-oncall/references/lessons.md
@@ -1,0 +1,49 @@
+# lessons.md: personal-products incident journal
+
+Status: seeded 2026-09-08; watching MCP write-path auth after donebear#408; slug conflicts should be 409 after donebear#412.
+
+Newest first. Search by #tag; do not ingest the whole file. Append after every resolved incident without asking.
+
+## Entry format
+
+```
+## YYYY-MM-DD · one-line title · #tag · PR-or-thread
+- Symptom: one fresh-reader sentence
+- Root cause: mechanism, with evidence
+- Fix / PR: what landed
+- Gotcha: the reusable rule
+```
+
+When a #tag hits 3 entries with the same mechanism, promote it into `oncall.md` by PR and leave a pointer here.
+
+---
+
+## 2026-09-08 · MCP server slug unique constraint returned 500 · #mcp-slug · donebear#412
+- Symptom: connecting an MCP server whose slug already existed (double-submit / GitHub already connected) threw Postgres unique constraint agent_mcp_servers_user_workspace_slug_key and landed in PostHog as a 500.
+- Root cause: `AgentMcpService.create` inserted without mapping unique violation `23505` to a domain error; reconnect already authorized the existing row.
+- Fix / PR: [donebear#412](https://github.com/donebear/donebear/pull/412) maps the conflict to `AGENT_MCP_SERVER_SLUG_TAKEN` (409) on create and rename.
+- Gotcha: a unique constraint bubbling as 500 is a client conflict, not an outage. Recreate is the wrong fix; 409 is.
+
+## 2026-09-07 · MCP writes Authentication required overnight · #mcp-oauth · donebear#408
+- Symptom: Grok/Cursor `tools/call` failed with Authentication required after ~1h while `tools/list` and `/health` stayed green on a 7-day MCP bearer.
+- Root cause: two tokens per grant. The MCP bearer (Redis, 7d) is what `verifyMcpAccessToken` checked. The upstream Supabase JWT (~1h `exp`) was snapshotted at issue time and forwarded on writes. Clients do not call `/token` until the MCP bearer is near expiry.
+- Fix / PR: [donebear#408](https://github.com/donebear/donebear/pull/408) refreshes the upstream JWT on the still-valid MCP grant (skew, 401/`UNAUTHORIZED` retry). Do not ask Matt to reauth.
+- Gotcha: after #408, this class is wake-now. A green MCP connector is not a live GraphQL user.
+
+## 2026-09 · Soft-404s passed status-only uptime · #soft-404
+- Symptom: the site served a 200 error page or empty shell; status-code monitors stayed green while users saw "not found" or a blank app.
+- Root cause: HTTP status proved the process, not the body.
+- Fix / PR: keyword monitors on a known healthy string (and absence of the error-page phrase). Status-only checks remain a complement, not the page signal.
+- Gotcha: keyword monitors beat status-code-only. A 200 is not proof the product rendered.
+
+## 2026-09 · /health green during a DB outage · #health-ready
+- Symptom: load balancers and `/health` reported up while clients failed to read or write.
+- Root cause: `/health` is process liveness. `/ready` is the DB (and required dependency) proof.
+- Fix / PR: page on `/ready`, not `/health`. After a fix, re-check `/ready` plus the original failing path.
+- Gotcha: `/ready` is DB proof; `/health` is process-only. Never clear an incident on `/health` 200.
+
+## 2026-09 · Desktop OAuth passed on Linux, failed on macOS · #desktop-oauth
+- Symptom: Tauri desktop OAuth looked done on a Linux agent VM, then failed for Matt on macOS.
+- Root cause: Linux WebKitGTK is not macOS WKWebView. Cookie, redirect, and custom-URL-scheme behavior diverge.
+- Fix / PR: treat Linux WebKit success as non-evidence for macOS. Validate OAuth on the WebKit that ships with the OS under test.
+- Gotcha: Linux WebKitGTK ≠ macOS WKWebView. Desktop OAuth needs a macOS check (or an explicit "Linux-only, unverified on macOS" label).

--- a/skills/done-bear-oncall/references/oncall.md
+++ b/skills/done-bear-oncall/references/oncall.md
@@ -1,0 +1,114 @@
+# On-call policy: Matt Blode personal products
+
+Standing triage for Done Bear, blode.co, blode.md, agent-skills, Stratasync, and Matt's OSS. Never Linktree (no Linktree Linear, Slack, or paging). Routines fetch this file remotely.
+
+## Contents
+
+- Fetch
+- Roles
+- Wake Matt now
+- Defer to morning / Autofix
+- Draft PR vs intent.md
+- Investigation
+- Verification and lessons
+- Products and signals
+- Paging log
+
+## Fetch
+
+Prefer installed files when this skill is on disk. Otherwise:
+
+```bash
+gh api repos/mblode/agent-skills/contents/skills/done-bear-oncall/references/oncall.md --jq .content | base64 -d
+gh api repos/mblode/agent-skills/contents/skills/done-bear-oncall/references/lessons.md --jq .content | base64 -d
+```
+
+Equivalent: `https://raw.githubusercontent.com/mblode/agent-skills/main/skills/done-bear-oncall/references/{oncall,lessons}.md`.
+
+Search lessons by #tag. Newest first. Do not ingest the whole journal.
+
+## Roles
+
+| Role | May | Must not |
+|------|-----|----------|
+| QA / Autofix / this skill | Triage, draft one PR, write `intent.md`, append lessons | Merge, close incidents, page Linktree |
+| Software Engineer / CTO | Merge, deploy, revert | Skip `/ready` after a prod fix |
+| CoS `07a643e4-c81c-47d4-9115-f81d5e3d6fc0` | Support intake on the wake path | Own the merge |
+
+## Wake Matt now
+
+Tell the user in-session **and** ping CoS `07a643e4-c81c-47d4-9115-f81d5e3d6fc0` when any of these hold:
+
+| Signal | Wake when |
+|--------|-----------|
+| UptimeRobot | Critical / prod down |
+| `/ready` | Failing (DB or dependency proof) |
+| PostHog exceptions | Band ≥20/hour on a product in scope |
+| MCP write | `Authentication required` class **after** donebear#408 |
+| Data / auth | Data-loss or auth outage |
+| Regression | Confirmed customer-blocking regression |
+
+Claude is not the detector. Deterministic monitors (UptimeRobot, `/ready`, exception band) page; this skill proposes severity for findings those monitors missed.
+
+`/health` is process-only. A green `/health` never clears a `/ready` fail and never blocks a wake.
+
+## Defer to morning / Autofix
+
+One sitrep line. No CoS ping. Autofix may open a draft; it still must not merge.
+
+- Single-user noise
+- `Script error`, extension frames, Turnstile, `ResizeObserver`
+- Known-fixed (a lessons.md entry with a merged PR, symptom gone on `/ready` + smoke)
+- Soft one-offs with no stack and no replay
+- CI flake whose retry is green
+
+If a deferred class starts matching a wake row (band ≥20/hour, `/ready` red, customer-blocking), promote it. Do not keep deferring by habit.
+
+## Draft PR vs intent.md
+
+| Situation | Output |
+|-----------|--------|
+| One-seam proven bug, evidence in one repo | **One draft PR.** Never merge. |
+| Multi-service, policy, or unclear owner | **`intent.md` to PM/CTO.** No speculative PR. |
+| Known-fixed or cannot reproduce | Sitrep only. No PR. |
+
+Draft means `isDraft: true` (or the host's draft equivalent). QA, Autofix, and this skill stop at the draft. Merge is Software Engineer / CTO.
+
+## Investigation
+
+1. Product in scope? If Linktree, stop.
+2. Wake table vs defer list.
+3. Search lessons.md for the #tag.
+4. Timeline: deploy, flag, config, merge in the onset window.
+5. Blast radius: who is blocked, which clients (web, desktop, MCP, iOS).
+6. Proposed fix: one seam, or `intent.md`.
+
+Diagnosis: what's happening, root cause with links, wake or defer, proposed fix, ruled out.
+
+## Verification and lessons
+
+After a human merge or deploy:
+
+1. Re-check `/ready` on the affected service.
+2. Re-run the original failing path (MCP write, the monitor keyword, the exception). A proxy that cannot see the symptom is a partial verify; say so.
+3. Append lessons.md, newest first: date, symptom, root cause, fix/PR, gotcha.
+4. If the playbook missed a branch, PR an amendment here. Recurring mechanism (3×) graduates into this file; leave a pointer in lessons.md.
+
+Would a monitor have caught this earlier? If detection was human or late, propose a paste-ready UptimeRobot keyword or PostHog trend, with this incident as provenance. Humans install monitors.
+
+## Products and signals
+
+| Product | Typical signals |
+|---------|-----------------|
+| Done Bear (`donebear/donebear`) | Fly manage-api `/ready`, PostHog exceptions, hosted MCP, desktop OAuth |
+| blode.co, blode.md | Uptime, Vercel |
+| agent-skills (`mblode/agent-skills`) | CI, this playbook |
+| Stratasync | iOS / local-first sync (Done Bear package) |
+| OSS | CI on Matt's public repos |
+| Linktree | Out of scope |
+
+Weather digest: `/ready`, UptimeRobot, exception rate, open drafts. Post only when something changed or a wake row trips. Silence is valid.
+
+## Paging log
+
+Every wake/no-wake decision is one line: signal, threshold, pinged or deferred, link. A deferred item that later wakes is a new decision, not a silent upgrade.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Personal-products on-call playbooks for Done Bear, blode.co, blode.md, agent-skills, Stratasync, and OSS, modeled on Anthropic's Claude-on-call pattern (deterministic triage plus a lessons loop).

## Skills added

- **done-bear-oncall**: QA / Autofix / prod webhook / weather-digest triage. Draft PRs only; never merge.

## Files

- `skills/done-bear-oncall/SKILL.md`: when to use, remote fetch, procedure
- `skills/done-bear-oncall/references/oncall.md`: wake vs defer, roles, draft PR vs `intent.md`, verification
- `skills/done-bear-oncall/references/lessons.md`: seeded journal (MCP OAuth #408, slug 409 #412, soft-404, `/ready` vs `/health`, WebKitGTK vs WKWebView)
- `skills/done-bear-oncall/evals/evals.json`: authored routing/behavior cases (house convention)

## README

- Skill count 25 → 26
- Shipping bullet for `done-bear-oncall`

No maintain skill exists in this repo, so no extra pointer was added. Out of scope: Linktree. Validator: `validate.sh skills/done-bear-oncall` is clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dcb56c9-25b3-47a5-9fba-28e30991b8e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dcb56c9-25b3-47a5-9fba-28e30991b8e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

