### PR TITLE
Harden rebuild-web verify against transient edge errors

### DIFF
--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -30,10 +30,23 @@ jobs:
         env:
           EXPECTED_SHA: ${{ github.sha }}
         run: |
+          # Actions IPs can see transient SSL errors, timeouts, and 403s from
+          # the edge while the Vercel deploy is still propagating. Keep polling
+          # until the timeout. Only HTTP 200 plus a matching (or descendant)
+          # synced-at SHA counts as success.
+          body="${RUNNER_TEMP:-/tmp}/llms-verify.txt"
+          status="000"
+          served=""
           for attempt in $(seq 1 60); do
-            served=$(curl --fail --silent --show-error --max-time 20 \
-              "https://blode.co/agent-skills/llms.txt" \
-              | sed -nE 's/.*\(synced at ([0-9a-f]{40})\).*/\1/p' | head -1) || served=""
+            status=$(curl --silent --show-error --max-time 20 \
+              --output "$body" --write-out "%{http_code}" \
+              -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36" \
+              "https://blode.co/agent-skills/llms.txt") || status="000"
+            served=""
+            if [ "$status" = "200" ]; then
+              served=$(sed -nE 's/.*\(synced at ([0-9a-f]{40})\).*/\1/p' "$body" | head -1)
+            fi
+            echo "attempt $attempt: HTTP $status served=${served:-none}"
             if [[ "$served" =~ ^[0-9a-f]{40}$ ]]; then
               if [ "$served" = "$EXPECTED_SHA" ]; then
                 echo "Published content verified: $served"
@@ -49,5 +62,5 @@ jobs:
             fi
             sleep 15
           done
-          echo "Website did not publish the expected source revision: $EXPECTED_SHA" >&2
+          echo "Website did not publish the expected source revision: $EXPECTED_SHA (last HTTP $status served=${served:-none})" >&2
           exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Rebuild agent-skills-web verify step was failing while `https://blode.co/agent-skills/llms.txt` was already serving the expected `synced at <sha>`.

Failed example: [run 34292936270](https://github.com/mblode/agent-skills/actions/runs/34292936270) (deploy hook succeeded; verify then saw connection reset, timeouts, `SSL_ERROR_SYSCALL`, and a long 403 streak). A later [manual re-run](https://github.com/mblode/agent-skills/actions/runs/34415912625) passed immediately because the content was already live.

`curl --fail` plus the default curl User-Agent hid HTTP status and treated WAF/edge 403s as "no SHA", so the loop burned out looking like a content miss.

This keeps the same URL and SHA contract, including the existing ancestor/descendant race check. Verify now:

- sends a browser User-Agent
- records HTTP status (and served SHA) on every attempt
- keeps polling on SSL/timeout/403 until the existing timeout
- succeeds only on HTTP 200 with `synced at` equal to `EXPECTED_SHA`, or a git descendant that contains it

Draft only. Please do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d3fd896-d25f-477e-af06-eae2e1cd34be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d3fd896-d25f-477e-af06-eae2e1cd34be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

