### PR TITLE
Fix rebuild-web verify against stale CDN and edge 403s

### DIFF
--- a/.github/workflows/rebuild-web.yml
+++ b/.github/workflows/rebuild-web.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   rebuild:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,28 +25,50 @@ jobs:
           DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK_AGENT_SKILLS_WEB }}
         run: |
           test -n "$DEPLOY_HOOK" || { echo "Missing website deploy hook secret" >&2; exit 1; }
+          # Hook JSON is only a PENDING job id. Waiting on Vercel readyState
+          # needs an API token this workflow does not have, so SHA verify below
+          # is the ready check.
           curl --fail --silent --show-error --retry 2 -X POST "$DEPLOY_HOOK" > /dev/null
       - name: Verify published content revision
         env:
           EXPECTED_SHA: ${{ github.sha }}
         run: |
-          # Actions IPs can see transient SSL errors, timeouts, and 403s from
-          # the edge while the Vercel deploy is still propagating. Keep polling
-          # until the timeout. Only HTTP 200 plus a matching (or descendant)
-          # synced-at SHA counts as success.
+          # Canonical /llms.txt is cached at the Vercel CDN (s-maxage=3600,
+          # x-vercel-cache: HIT). Matching deploys are READY in about 30s, but
+          # polling that URL every 15s from Actions IPs kept serving the
+          # previous main SHA, then flipped to HTTP 403 around attempt 33
+          # (runs 34463626162, 34423624748). Query params miss the no-query
+          # cache object; wait until READY before the first fetch so a MISS
+          # does not PRERENDER the previous SHA into that bucket. Back off on
+          # 403/429 so the remaining budget is not burned while the edge is
+          # blocking. Stay well under ~32 requests. Only HTTP 200 plus a
+          # matching (or descendant) synced-at SHA counts as success.
           body="${RUNNER_TEMP:-/tmp}/llms-verify.txt"
+          hdr="${RUNNER_TEMP:-/tmp}/llms-verify.hdr"
           status="000"
           served=""
-          for attempt in $(seq 1 60); do
+          attempt=0
+          sleep_s=45
+          deadline=$((SECONDS + 1200))
+          echo "waiting 40s for the deploy hook build to reach READY"
+          sleep 40
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            attempt=$((attempt + 1))
             status=$(curl --silent --show-error --max-time 20 \
-              --output "$body" --write-out "%{http_code}" \
+              --dump-header "$hdr" --output "$body" --write-out "%{http_code}" \
               -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36" \
-              "https://blode.co/agent-skills/llms.txt") || status="000"
+              -H "Cache-Control: no-cache" \
+              -H "Pragma: no-cache" \
+              "https://blode.co/agent-skills/llms.txt?revision=${EXPECTED_SHA}&attempt=${attempt}") || status="000"
             served=""
+            xcache=""
+            if [ -f "$hdr" ]; then
+              xcache=$(tr -d '\r' < "$hdr" | sed -nE 's/^[Xx]-[Vv]ercel-[Cc]ache:[[:space:]]*//p' | tail -1)
+            fi
             if [ "$status" = "200" ]; then
               served=$(sed -nE 's/.*\(synced at ([0-9a-f]{40})\).*/\1/p' "$body" | head -1)
             fi
-            echo "attempt $attempt: HTTP $status served=${served:-none}"
+            echo "attempt $attempt: HTTP $status x-vercel-cache=${xcache:-none} served=${served:-none}"
             if [[ "$served" =~ ^[0-9a-f]{40}$ ]]; then
               if [ "$served" = "$EXPECTED_SHA" ]; then
                 echo "Published content verified: $served"
@@ -60,7 +82,22 @@ jobs:
                 exit 0
               fi
             fi
-            sleep 15
+            if [ "$status" = "403" ] || [ "$status" = "429" ]; then
+              sleep_s=$((sleep_s < 90 ? sleep_s * 2 : 120))
+              echo "edge blocked HTTP $status; backing off ${sleep_s}s"
+            elif [ "$status" = "000" ]; then
+              sleep_s=20
+            else
+              sleep_s=45
+            fi
+            remaining=$((deadline - SECONDS))
+            if [ "$remaining" -le 0 ]; then
+              break
+            fi
+            if [ "$sleep_s" -gt "$remaining" ]; then
+              sleep_s=$remaining
+            fi
+            sleep "$sleep_s"
           done
           echo "Website did not publish the expected source revision: $EXPECTED_SHA (last HTTP $status served=${served:-none})" >&2
           exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Push rebuilds of agent-skills-web were failing after the content deploy was already READY. Manual `workflow_dispatch` later went green because `llms.txt` already had the expected SHA.

Verified on [run 34463626162](https://github.com/mblode/agent-skills/actions/runs/34463626162) (`0144e3f`, #26) and [run 34423624748](https://github.com/mblode/agent-skills/actions/runs/34423624748) (`aec0a60`, #25):
- Attempts 1-32: HTTP 200 serving the **previous** main SHA
- Attempts 33-60: HTTP 403 `served=none`
- Matching Vercel production deploys were READY in about 30s (`dpl_21WP29NZ…`, `dpl_6UTcEPXV…`)
- Live `https://blode.co/agent-skills/llms.txt` is CDN-cached (`x-vercel-cache: HIT`, `s-maxage=3600`). The no-query URL and any-query URL are different cache objects; query strings share one object.

#25's User-Agent and HTTP logging did not change this. There is no Vercel API token in this workflow (only `VERCEL_DEPLOY_HOOK_AGENT_SKILLS_WEB`), so verify cannot wait on `readyState`.

`.github/workflows/rebuild-web.yml` now:
- Waits 40s after the hook so the first fetch is after READY (avoids PRERENDER of the old SHA into the query cache bucket)
- Polls `llms.txt?revision=$EXPECTED_SHA&attempt=$N` with `Cache-Control`/`Pragma: no-cache` (misses the sticky no-query CDN object)
- Polls every 45s for up to 20 minutes, backs off to 90-120s on 403/429 (stays under the ~32-request Actions-IP 403)
- Still succeeds only on HTTP 200 with `synced at` equal to `EXPECTED_SHA`, or a git descendant that contains it
- Still fails if that SHA never appears

Draft only. Please do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d61d92d-bdd9-461c-b05d-9285fa7ccd01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d61d92d-bdd9-461c-b05d-9285fa7ccd01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

